### PR TITLE
TEST: verify the governance bot catches a real regression

### DIFF
--- a/deploy/compose/optic.yaml
+++ b/deploy/compose/optic.yaml
@@ -63,12 +63,10 @@ rules:
     match:
       path: "/api/v1/payments/**"
     redact:
-      headers: [Authorization, X-Api-Key, Cookie]
+      headers: [Authorization, X-Api-Key]
       query_params: [api_key, session]
       json_fields:
         - "$.**.credit_card.number"
-        - "$.**.credit_card.cvv"
-        - "$.**.customer.email"
     labels:
       tenant: "header:X-Tenant-ID"
       region: "header:X-Region"

--- a/deploy/compose/optic.yaml
+++ b/deploy/compose/optic.yaml
@@ -63,7 +63,7 @@ rules:
     match:
       path: "/api/v1/payments/**"
     redact:
-      headers: [Authorization, X-Api-Key]
+      headers: [Authorization, X-Api-Key, Cookie]
       query_params: [api_key, session]
       json_fields:
         - "$.**.credit_card.number"


### PR DESCRIPTION
Deliberately weakens governance in `deploy/compose/optic.yaml` to prove the review bot works inside a real GitHub Actions runner — the gap tracked in #1.

This PR drops `$.**.credit_card.cvv`, `$.**.customer.email` and the `Cookie` header from the payments redaction rule, framed the way such a regression usually arrives: as a tidy-up.

Expected: the bot posts one comment, flags the dropped redactions as blocking, and fails the check. **Not for merge** — it will be closed once the behaviour is confirmed.