### PR TITLE
TEST: verify a no-op PR stays green

### DIFF
--- a/deploy/compose/optic.yaml
+++ b/deploy/compose/optic.yaml
@@ -44,6 +44,7 @@ telemetry:
         tokens: 0.000002       # $2 per 1M tokens
 
 defaults:
+  # Capture is opt-out: everything is recorded unless a rule restricts it.
   capture:
     request_body: true
     response_body: true


### PR DESCRIPTION
Second half of the #1 verification. Touches `deploy/compose/optic.yaml` — inside the governance workflow's trigger paths — but changes only a comment.

The repo has pre-existing ungoverned fields, which the bot reports. Those must **not** fail this check: the bot's contract is to fail for what the PR changed, not for what was already there.

Expected: the check passes, and the comment lists the pre-existing findings as informational. **Not for merge.**