### PR TITLE
fix: close the app-log correctness gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Versions `0.4.0`–`0.6.0` were development milestones that were never tagged;
 `0.7.0` is the first public release and contains all of that work.
 
+## [Unreleased]
+
+### Added
+
+- **Postgres and ClickHouse store application logs.** Previously SQLite only, so the feature was unavailable on exactly the multi-node deployments most likely to want it. Both implement the full `ext.AppLogStore` and both erase log lines together with the records a `purge` removes — ClickHouse deletes the lines first, because it has no transaction across the two mutations and a retry is safe while an orphaned line nothing can match again is not.
+
+- **`ext/exttest` asserts the app-log contract**, including the erasure rule that `ext/applog.go` documents. That rule cannot be inferred from the interface signatures: a driver can implement `Store` and `AppLogStore` perfectly and still leave a purged tenant's log lines behind, and a log is the likelier place for the personal data to be sitting. The sub-tests skip for a driver without app-log support, so the interface stays genuinely optional. Verified by breaking each driver's purge in turn and watching the suite fail.
+
+- **`optictrace scan` reads application log lines**, not only payloads. It was looking where the data is easiest to protect rather than where it escapes — a record whose body is `{"amount":42}` scanned clean while a card number sat in a log line attached to it. Findings group by service and level, and the suggested fix is a pattern or field name under `app_logs.redact` rather than a `json_fields` path, which could not work on free text. Both `optictrace scan` and `GET /api/scan` now report how many log lines were read alongside the record count.
+
 ## [0.10.0] — 2026-08-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1044,10 +1044,19 @@ Three consequences worth knowing before you turn it on:
   `optictrace_app_logs_dropped_total{reason="orphan"}` — data discarded
   silently is data nobody knows they are missing. Set `drop_orphans: false` to
   keep them unattributed.
+- **`optictrace scan` reads them too.** A payload is structured and can be
+  masked by JSON path; a log line is free text. A leak detector that only reads
+  payloads looks where the data is easiest to protect rather than where it
+  escapes, so scan reports on both and the suggested fix differs — a pattern or
+  a field name under `app_logs.redact`, not a `json_fields` path that could not
+  work here. The count is reported as "N record(s) and M log line(s)", because
+  no findings over zero lines means something very different from no findings
+  over forty thousand.
 - **Storage support is optional.** `ext.AppLogStore` is a separate interface
   from `ext.Store`, so a third-party driver that does not implement it is still
-  a complete driver. The endpoint says which of the two problems you have —
-  the feature is off, or your driver cannot store lines.
+  a complete driver — but a driver that DOES implement it must also erase log
+  lines in `Purge`, and `ext/exttest` asserts exactly that. All three built-in
+  drivers (SQLite, Postgres, ClickHouse) pass it.
 
 ---
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -386,12 +386,16 @@ func scanTraffic(configPath string, window time.Duration, failOn string) {
 	for i := range records {
 		sc.Add(&records[i])
 	}
+	// And the application log lines, which are the riskier surface: a payload
+	// is structured and can be masked by JSON path, a log line is free text
+	// written by whoever was debugging that day.
+	scanAppLogs(sc, cfg, window)
 	report := sc.Report()
 	crit, high, med := report.Counts()
 
 	if len(report.Findings) == 0 {
-		fmt.Printf("✓ scanned %d record(s) over %s — no sensitive values found outside your rules\n",
-			report.Scanned, window)
+		fmt.Printf("✓ scanned %s over %s — no sensitive values found outside your rules\n",
+			scannedSummary(report), window)
 		return
 	}
 
@@ -403,8 +407,8 @@ func scanTraffic(configPath string, window time.Duration, failOn string) {
 			f.Why, f.Count, ago(f.LastAt), f.Sample)
 		fmt.Printf("    fix: %s\n\n", strings.ReplaceAll(f.Suggest, "\n", "\n         "))
 	}
-	fmt.Printf("scanned %d record(s): %d critical, %d high, %d medium\n",
-		report.Scanned, crit, high, med)
+	fmt.Printf("scanned %s: %d critical, %d high, %d medium\n",
+		scannedSummary(report), crit, high, med)
 
 	if failOn != "never" && report.HasAtLeast(failOn) {
 		fmt.Fprintf(os.Stderr, "\n✗ sensitive data found at or above severity %q\n", failOn)
@@ -454,6 +458,51 @@ func ago(t time.Time) string {
 }
 
 // loadTraffic opens the configured store read-only and pulls the window.
+// scannedSummary names what was actually read. "0 findings" over 0 log lines
+// means something very different from 0 findings over 40,000 of them, and the
+// difference is invisible unless it is printed.
+func scannedSummary(r *scan.Report) string {
+	if r.LinesScanned == 0 {
+		return fmt.Sprintf("%d record(s)", r.Scanned)
+	}
+	return fmt.Sprintf("%d record(s) and %d log line(s)", r.Scanned, r.LinesScanned)
+}
+
+// scanAppLogs feeds stored application log lines to the scanner. A store
+// driver without app-log support, or a config with the feature off, simply
+// contributes nothing — this is an optional surface, not a required one.
+func scanAppLogs(sc *scan.Scanner, cfg *config.Config, window time.Duration) {
+	if cfg == nil || cfg.Telemetry.AppLogs == nil || !cfg.Telemetry.AppLogs.Enabled {
+		return
+	}
+	st, err := openStore(&cfg.Telemetry.Store)
+	if err != nil {
+		return
+	}
+	defer st.Close()
+	als, ok := st.(store.AppLogStore)
+	if !ok {
+		return
+	}
+	since := time.Now().Add(-window)
+	limit := store.AnalysisLimit(cfg.Telemetry.Store.AnalysisMaxRows)
+	for offset := 0; offset < limit; {
+		lines, total, err := als.QueryAppLogs(context.Background(), store.AppLogFilter{
+			Since: since, Limit: 500, Offset: offset,
+		})
+		if err != nil || len(lines) == 0 {
+			return
+		}
+		for i := range lines {
+			sc.AddAppLog(&lines[i])
+		}
+		offset += len(lines)
+		if int64(offset) >= total {
+			return
+		}
+	}
+}
+
 func loadTraffic(configPath string, window time.Duration) (*config.Config, []store.Record) {
 	cfg, err := config.Load(configPath)
 	if err != nil {

--- a/ext/exttest/conformance.go
+++ b/ext/exttest/conformance.go
@@ -70,6 +70,173 @@ func RunStoreSuite(t *testing.T, open OpenFunc) {
 	t.Run("retention_by_rows", func(t *testing.T) { testPrune(t, open) })
 	t.Run("recent_func", func(t *testing.T) { testRecentFunc(t, open) })
 	t.Run("streams_excluded_from_percentiles", func(t *testing.T) { testStreams(t, open) })
+
+	// App logs are OPTIONAL: a driver that does not implement ext.AppLogStore
+	// is a complete driver, and these sub-tests skip rather than fail. What
+	// they must not do is silently not run for a driver that DOES implement
+	// it — which is why the assertion lives here rather than in one driver's
+	// own tests.
+	t.Run("app_logs", func(t *testing.T) { testAppLogs(t, open) })
+	t.Run("app_logs_erasure", func(t *testing.T) { testAppLogErasure(t, open) })
+}
+
+// appLogStore returns the driver's app-log side, or skips the sub-test.
+func appLogStore(t *testing.T, s ext.Store) ext.AppLogStore {
+	t.Helper()
+	als, ok := s.(ext.AppLogStore)
+	if !ok {
+		t.Skip("driver does not implement ext.AppLogStore (optional)")
+	}
+	return als
+}
+
+// AppLog builds a representative line, exported so a driver's own tests can
+// reuse the shape the suite exercises.
+func AppLog(at time.Time, trace, span, level, message string) ext.AppLog {
+	return ext.AppLog{
+		Time: at, Service: "api", TraceID: trace, SpanID: span,
+		Level: level, Message: message, Source: "test",
+		Fields: map[string]string{"k": "v"},
+	}
+}
+
+func testAppLogs(t *testing.T, open OpenFunc) {
+	ctx := context.Background()
+	s := open(t)
+	als := appLogStore(t, s)
+
+	base := time.Now().Add(-time.Minute).UTC().Truncate(time.Millisecond)
+	// Written out of order deliberately: reading what a request did means
+	// reading it in the order it happened, not the order it was stored.
+	lines := []ext.AppLog{
+		AppLog(base.Add(2*time.Second), "t1", "s1", "error", "third"),
+		AppLog(base, "t1", "s1", "info", "first"),
+		AppLog(base.Add(time.Second), "t1", "s1", "warn", "second"),
+		AppLog(base, "t2", "s2", "info", "another request"),
+	}
+	if err := als.SaveAppLogs(ctx, lines); err != nil {
+		t.Fatalf("SaveAppLogs: %v", err)
+	}
+
+	got, total, err := als.QueryAppLogs(ctx, ext.AppLogFilter{SpanID: "s1"})
+	if err != nil {
+		t.Fatalf("QueryAppLogs: %v", err)
+	}
+	if total != 3 || len(got) != 3 {
+		t.Fatalf("span s1: %d line(s), total %d, want 3", len(got), total)
+	}
+	for i, want := range []string{"first", "second", "third"} {
+		if got[i].Message != want {
+			t.Errorf("position %d = %q, want %q — lines must come back oldest-first",
+				i, got[i].Message, want)
+		}
+	}
+	if got[0].Fields["k"] != "v" {
+		t.Errorf("structured fields lost in round-trip: %v", got[0].Fields)
+	}
+	if !got[0].Time.Equal(base) {
+		t.Errorf("timestamp round-trip: got %s want %s", got[0].Time, base)
+	}
+	if got[0].TraceID != "t1" || got[0].Level != "info" {
+		t.Errorf("field round-trip: %+v", got[0])
+	}
+
+	// Trace selects every hop's lines; span selects one hop's.
+	if _, total, err := als.QueryAppLogs(ctx, ext.AppLogFilter{TraceID: "t1"}); err != nil || total != 3 {
+		t.Errorf("trace filter: total=%d err=%v, want 3", total, err)
+	}
+
+	// Level is compared by SEVERITY, not alphabetically — "error" sorts before
+	// "warn" as text and after it as severity, so a lexical comparison returns
+	// the wrong set here.
+	sev, _, err := als.QueryAppLogs(ctx, ext.AppLogFilter{SpanID: "s1", LevelMin: "warn"})
+	if err != nil {
+		t.Fatalf("level filter: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, l := range sev {
+		seen[l.Level] = true
+	}
+	if !seen["warn"] || !seen["error"] || seen["info"] {
+		t.Errorf("level_min=warn selected %v, want warn+error and not info", seen)
+	}
+
+	if n, err := als.CountAppLogs(ctx); err != nil || n != 4 {
+		t.Errorf("CountAppLogs = %d (err %v), want 4", n, err)
+	}
+
+	sum, err := als.AppLogStats(ctx, base.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("AppLogStats: %v", err)
+	}
+	if sum.Total != 4 || sum.ByLevel["info"] != 2 || sum.SpansWithLogs != 2 {
+		t.Errorf("stats = %+v, want total 4, info 2, spans 2", sum)
+	}
+
+	// Retention is separate from the record horizon: app logs outgrow records
+	// by orders of magnitude and are rarely wanted for as long.
+	removed, err := als.PruneAppLogsBefore(ctx, base.Add(500*time.Millisecond))
+	if err != nil {
+		t.Fatalf("PruneAppLogsBefore: %v", err)
+	}
+	if removed != 2 {
+		t.Errorf("pruned %d line(s), want 2", removed)
+	}
+	if n, _ := als.CountAppLogs(ctx); n != 2 {
+		t.Errorf("%d line(s) survived, want 2", n)
+	}
+}
+
+// testAppLogErasure is the reason this suite covers app logs at all.
+//
+// Erasure that deletes a tenant's requests but leaves the lines those requests
+// wrote is not erasure — and a log line is the LIKELIER place for the personal
+// data to be sitting, because nobody redacts a log as carefully as a payload.
+// A driver implementing both Store and AppLogStore must handle this in Purge;
+// it is the one part of the contract that cannot be inferred from the
+// interface signatures.
+func testAppLogErasure(t *testing.T, open OpenFunc) {
+	ctx := context.Background()
+	s := open(t)
+	als := appLogStore(t, s)
+
+	save := func(trace, tenant string) {
+		t.Helper()
+		rec := Record(200, 5, "/api/v1/payments/charge", tenant)
+		rec.TraceID = trace
+		rec.SpanID = trace + "-span"
+		mustSave(t, s, rec)
+		if err := als.SaveAppLogs(ctx, []ext.AppLog{
+			AppLog(time.Now().UTC(), trace, trace+"-span", "info", "processing for "+tenant),
+		}); err != nil {
+			t.Fatalf("SaveAppLogs: %v", err)
+		}
+	}
+	save("trace-acme", "acme")
+	save("trace-globex", "globex")
+
+	if _, err := s.Purge(ctx, "tenant", "acme", time.Time{}); err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+
+	gone, _, err := als.QueryAppLogs(ctx, ext.AppLogFilter{TraceID: "trace-acme"})
+	if err != nil {
+		t.Fatalf("QueryAppLogs: %v", err)
+	}
+	if len(gone) != 0 {
+		t.Errorf("purge left %d app log line(s) behind — erasure that keeps the "+
+			"lines a purged tenant's requests wrote is not erasure: %+v", len(gone), gone)
+	}
+
+	// And it must not take a bystander's data with it, the same way Purge
+	// itself must match the label value literally.
+	kept, _, err := als.QueryAppLogs(ctx, ext.AppLogFilter{TraceID: "trace-globex"})
+	if err != nil {
+		t.Fatalf("QueryAppLogs: %v", err)
+	}
+	if len(kept) != 1 {
+		t.Errorf("purge destroyed a bystander's log lines: %d remain, want 1", len(kept))
+	}
 }
 
 func testRoundtrip(t *testing.T, open OpenFunc) {

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -559,6 +559,30 @@ func (s *Server) scan(w http.ResponseWriter, r *http.Request) {
 		httpError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	// Application logs are the other half of the surface, and the riskier one:
+	// a payload is structured and can be masked by path, a log line is free
+	// text. Scanning records but not lines would look where the data is
+	// easiest to protect rather than where it escapes.
+	if s.AppLogStore != nil {
+		offset := 0
+		for {
+			lines, total, err := s.AppLogStore.QueryAppLogs(r.Context(), store.AppLogFilter{
+				Since: since, Limit: 500, Offset: offset,
+			})
+			if err != nil {
+				httpError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			for i := range lines {
+				sc.AddAppLog(&lines[i])
+			}
+			offset += len(lines)
+			if len(lines) == 0 || int64(offset) >= total || offset >= s.analysisRows() {
+				break
+			}
+		}
+	}
+
 	report := sc.Report()
 	ext.NoteAccess(r.Context(), ext.Accessed{Count: report.Scanned, Filter: auditableQuery(r)})
 	crit, high, med := report.Counts()
@@ -567,11 +591,14 @@ func (s *Server) scan(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"records_scanned": report.Scanned,
-		"since":           report.Since,
-		"critical":        crit,
-		"high":            high,
-		"medium":          med,
-		"findings":        report.Findings,
+		// Reported so "0 findings" can be read honestly: none over zero log
+		// lines means something very different from none over forty thousand.
+		"log_lines_scanned": report.LinesScanned,
+		"since":             report.Since,
+		"critical":          crit,
+		"high":              high,
+		"medium":            med,
+		"findings":          report.Findings,
 	})
 }
 
@@ -1044,6 +1071,16 @@ func (s *Server) queryAppLogs(w http.ResponseWriter, r *http.Request) {
 		lines = []store.AppLog{}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"lines": lines, "total": total})
+}
+
+// analysisRows is the row bound for the analysis endpoints, resolved. App logs
+// run orders of magnitude above request volume, so an unbounded scan of them
+// would read far more than the equivalent record scan.
+func (s *Server) analysisRows() int {
+	if s.AnalysisMaxRows > 0 {
+		return s.AnalysisMaxRows
+	}
+	return store.DefaultAnalysisMaxRows
 }
 
 // appLogStats returns aggregate counts for the dashboard. It exposes no

--- a/internal/scan/applog_test.go
+++ b/internal/scan/applog_test.go
@@ -1,0 +1,91 @@
+package scan
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dwarka-prasad/optictrace/ext"
+)
+
+// A leak detector that only reads payloads is looking where the data is
+// easiest to protect rather than where it escapes. This is the surface that
+// carries tokens and whole request bodies inside stack traces.
+func TestScannerFindsSecretsInLogLines(t *testing.T) {
+	sc := NewScanner(time.Now().Add(-time.Hour))
+	now := time.Now()
+
+	sc.AddAppLog(&ext.AppLog{
+		Time: now, Service: "payments", Level: "debug",
+		Message: "charging card 4111111111111111 for tenant acme",
+	})
+	sc.AddAppLog(&ext.AppLog{
+		Time: now, Service: "payments", Level: "error",
+		Message: "gateway rejected",
+		Fields:  map[string]string{"card": "4111111111111111", "amount": "42"},
+	})
+
+	rep := sc.Report()
+	if rep.LinesScanned != 2 {
+		t.Errorf("LinesScanned = %d, want 2", rep.LinesScanned)
+	}
+	if len(rep.Findings) == 0 {
+		t.Fatal("no findings — a card number in a log line went unnoticed")
+	}
+
+	var inMessage, inField *Finding
+	for i := range rep.Findings {
+		f := &rep.Findings[i]
+		if f.Location != "app_log" {
+			t.Errorf("finding location = %q, want app_log", f.Location)
+		}
+		switch f.Field {
+		case "message":
+			inMessage = f
+		case "card":
+			inField = f
+		}
+	}
+	if inMessage == nil {
+		t.Error("a secret in the message text was not found")
+	}
+	if inField == nil {
+		t.Error("a secret in a structured field was not found")
+	}
+
+	// The sample must never be the raw value — a leak report that reprints the
+	// leak is a second copy of it.
+	for _, f := range rep.Findings {
+		if strings.Contains(f.Sample, "4111111111111111") {
+			t.Errorf("finding sample leaked the raw value: %q", f.Sample)
+		}
+	}
+
+	// The suggested fix has to be one that works here. A log line has no JSON
+	// path, so suggesting redact.json_fields would be advice that cannot help.
+	if inMessage != nil {
+		if !strings.Contains(inMessage.Suggest, "app_logs") {
+			t.Errorf("suggestion does not point at app_logs config: %q", inMessage.Suggest)
+		}
+		if strings.Contains(inMessage.Suggest, "json_fields") {
+			t.Errorf("suggested a JSON path for a free-text log line: %q", inMessage.Suggest)
+		}
+	}
+	if inField != nil && !strings.Contains(inField.Suggest, "fields: [card]") {
+		t.Errorf("a structured field should be fixable by name: %q", inField.Suggest)
+	}
+}
+
+// A clean log line must not invent findings, and the count still has to be
+// reported — "0 findings" means something different when nothing was read.
+func TestScannerReportsLinesScannedEvenWithNoFindings(t *testing.T) {
+	sc := NewScanner(time.Now().Add(-time.Hour))
+	sc.AddAppLog(&ext.AppLog{Time: time.Now(), Service: "api", Level: "info", Message: "order placed"})
+	rep := sc.Report()
+	if len(rep.Findings) != 0 {
+		t.Errorf("invented %d finding(s) from a clean line", len(rep.Findings))
+	}
+	if rep.LinesScanned != 1 {
+		t.Errorf("LinesScanned = %d, want 1", rep.LinesScanned)
+	}
+}

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dwarka-prasad/optictrace/ext"
 	"github.com/dwarka-prasad/optictrace/internal/store"
 )
 
@@ -21,7 +22,7 @@ type Finding struct {
 	Why      string    `json:"why"`
 	Method   string    `json:"method"`
 	Route    string    `json:"route"`
-	Location string    `json:"location"` // request_body | response_body | request_headers | response_headers
+	Location string    `json:"location"` // request_body | response_body | request_headers | response_headers | app_log
 	Field    string    `json:"field"`    // JSON path or header name
 	Count    int       `json:"count"`
 	FirstAt  time.Time `json:"first_seen"`
@@ -33,9 +34,13 @@ type Finding struct {
 
 // Report is a complete scan result.
 type Report struct {
-	Scanned  int       `json:"records_scanned"`
-	Since    time.Time `json:"since"`
-	Findings []Finding `json:"findings"`
+	Scanned int `json:"records_scanned"`
+	// LinesScanned counts application log lines examined. Reported separately
+	// from records because "0 findings" means something very different when
+	// no log lines were looked at than when thousands were.
+	LinesScanned int       `json:"log_lines_scanned"`
+	Since        time.Time `json:"since"`
+	Findings     []Finding `json:"findings"`
 }
 
 // Counts summarizes findings by severity.
@@ -77,10 +82,11 @@ type key struct{ kind, method, route, location, field string }
 // gigabytes resident before the first detector runs, on an endpoint that is
 // reachable without authentication. Folding incrementally costs one record.
 type Scanner struct {
-	agg       map[key]*Finding
-	scanned   int
-	since     time.Time
-	detectors []Detector
+	linesScanned int
+	agg          map[key]*Finding
+	scanned      int
+	since        time.Time
+	detectors    []Detector
 }
 
 // NewScanner scans with the built-in detector set.
@@ -149,6 +155,63 @@ func (s *Scanner) Add(rec *store.Record) {
 	}
 }
 
+// AddAppLog scans one application log line.
+//
+// This surface matters more than the payloads, not less. A payload is
+// structured and can be masked by JSON path; a log line is free text written by
+// whoever was debugging that day, and it routinely carries tokens and whole
+// request bodies inside stack traces. A leak detector that only reads payloads
+// is looking where the data is easiest to protect rather than where it escapes.
+//
+// Findings group by service and level rather than by route, because that is
+// what a log line has: the code that wrote it is identified by the service it
+// ran in, not by the request that happened to trigger it.
+func (s *Scanner) AddAppLog(l *ext.AppLog) {
+	s.linesScanned++
+
+	record := func(field, value string) {
+		for _, m := range FindWith(s.detectors, value) {
+			k := key{m.Kind, l.Service, "log:" + l.Level, "app_log", field}
+			f := s.agg[k]
+			if f == nil {
+				f = &Finding{
+					Kind: m.Kind, Severity: m.Severity, Why: m.Why,
+					Method: l.Service, Route: "log:" + l.Level,
+					Location: "app_log", Field: field,
+					Sample: m.Masked, FirstAt: l.Time,
+					Suggest: suggestAppLog(field),
+				}
+				s.agg[k] = f
+			}
+			f.Count++
+			if l.Time.Before(f.FirstAt) {
+				f.FirstAt = l.Time
+			}
+			if l.Time.After(f.LastAt) {
+				f.LastAt = l.Time
+			}
+		}
+	}
+
+	record("message", l.Message)
+	for name, val := range l.Fields {
+		record(name, val)
+	}
+}
+
+// suggestAppLog produces the fix for a value found in a log line.
+//
+// Deliberately different from the payload suggestion: there is no JSON path to
+// name, so the fix is a pattern (or a field name) under
+// telemetry.app_logs.redact. Suggesting `json_fields` here would be advice
+// that cannot work.
+func suggestAppLog(field string) string {
+	if field == "message" {
+		return "telemetry:\n  app_logs:\n    redact:\n      patterns: ['<a regex matching this value>']"
+	}
+	return fmt.Sprintf("telemetry:\n  app_logs:\n    redact:\n      fields: [%s]", field)
+}
+
 // Report finalises the accumulated findings, most severe first.
 func (s *Scanner) Report() *Report {
 	out := make([]Finding, 0, len(s.agg))
@@ -165,7 +228,7 @@ func (s *Scanner) Report() *Report {
 		}
 		return out[i].Field < out[j].Field
 	})
-	return &Report{Scanned: s.scanned, Since: s.since, Findings: out}
+	return &Report{Scanned: s.scanned, LinesScanned: s.linesScanned, Since: s.since, Findings: out}
 }
 
 // Records scans a slice of stored telemetry. Equivalent to feeding each record

--- a/internal/store/clickhouse.go
+++ b/internal/store/clickhouse.go
@@ -70,6 +70,28 @@ ENGINE = MergeTree
 ORDER BY (ts, id)
 SETTINGS index_granularity = 8192`
 
+// chAppLogSchema is a separate table, not more columns on logs: many lines per
+// exchange is a different cardinality entirely, and app logs want their own
+// retention horizon.
+const chAppLogSchema = `
+CREATE TABLE IF NOT EXISTS app_logs (
+	id        Int64,
+	ts        Int64,
+	service   String,
+	trace_id  String,
+	span_id   String,
+	level     String,
+	message   String,
+	fields    String,
+	source    String,
+	truncated UInt8
+)
+ENGINE = MergeTree
+-- span_id leads: "what did this request log" is the point, and it is the only
+-- lookup that has to be fast on the fastest-growing table in the store.
+ORDER BY (span_id, ts, id)
+SETTINGS index_granularity = 8192`
+
 // NewClickHouse opens (and migrates) a ClickHouse-backed store. dsn is a
 // clickhouse-go URL: clickhouse://user:pass@host:9000/database
 func NewClickHouse(dsn string) (*ClickHouseStore, error) {
@@ -93,6 +115,10 @@ func NewClickHouse(dsn string) (*ClickHouseStore, error) {
 	if _, err := db.ExecContext(ctx, chSchema); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("apply schema: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, chAppLogSchema); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("apply app-log schema: %w", err)
 	}
 	// Columns added after the initial release. ClickHouse has IF NOT EXISTS
 	// for this, so no error-string matching is needed.
@@ -602,6 +628,49 @@ func (s *ClickHouseStore) Purge(ctx context.Context, label, value string, before
 	if n == 0 {
 		return 0, nil
 	}
+	// Erasure has to take the application log lines with it. A tenant's
+	// requests deleted while the lines those requests wrote survive is not
+	// erasure, and a log is the likelier place for the personal data to be.
+	//
+	// ClickHouse has no transactions across these two mutations, so the log
+	// lines go FIRST: if the second delete fails, the caller sees an error and
+	// retries, and a retry is safe. The other order could report failure while
+	// having already removed the records, leaving orphaned lines nothing will
+	// ever match again.
+	var traceIDs []string
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT DISTINCT trace_id FROM logs WHERE `+where+` AND trace_id != ''`, args...)
+	if err != nil {
+		return 0, err
+	}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		traceIDs = append(traceIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return 0, err
+	}
+	rows.Close()
+
+	if len(traceIDs) > 0 {
+		ids := make([]any, len(traceIDs))
+		placeholders := make([]string, len(traceIDs))
+		for i, id := range traceIDs {
+			ids[i] = id
+			placeholders[i] = "?"
+		}
+		if _, err := s.db.ExecContext(ctx,
+			`ALTER TABLE app_logs DELETE WHERE trace_id IN (`+
+				strings.Join(placeholders, ",")+`)`+syncMutations, ids...); err != nil {
+			return 0, fmt.Errorf("purge app logs: %w", err)
+		}
+	}
+
 	if _, err := s.db.ExecContext(ctx,
 		`ALTER TABLE logs DELETE WHERE `+where+syncMutations, args...); err != nil {
 		return 0, err

--- a/internal/store/clickhouse_applog.go
+++ b/internal/store/clickhouse_applog.go
@@ -1,0 +1,225 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/dwarka-prasad/optictrace/ext"
+)
+
+// ClickHouseStore implements ext.AppLogStore.
+var _ ext.AppLogStore = (*ClickHouseStore)(nil)
+
+// SaveAppLogs writes a batch.
+//
+// ClickHouse has no autoincrement, so ids come from the same timestamp+sequence
+// generator the record path uses — monotonic enough to order lines written in
+// the same millisecond, which is exactly when a request logs several times.
+func (s *ClickHouseStore) SaveAppLogs(ctx context.Context, lines []ext.AppLog) error {
+	if len(lines) == 0 {
+		return nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO app_logs (id, ts, service, trace_id, span_id, level, message, fields, source, truncated)
+		VALUES (?,?,?,?,?,?,?,?,?,?)`)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	for i := range lines {
+		l := &lines[i]
+		if l.Time.IsZero() {
+			l.Time = time.Now()
+		}
+		fields := ""
+		if len(l.Fields) > 0 {
+			raw, err := json.Marshal(l.Fields)
+			if err != nil {
+				tx.Rollback()
+				return err
+			}
+			fields = string(raw)
+		}
+		if _, err := stmt.ExecContext(ctx, s.nextID(l.Time), l.Time.UnixMilli(), l.Service,
+			l.TraceID, l.SpanID, l.Level, l.Message, fields, l.Source,
+			uint8(boolInt(l.Truncated))); err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// QueryAppLogs returns matching lines oldest-first.
+func (s *ClickHouseStore) QueryAppLogs(ctx context.Context, f ext.AppLogFilter) ([]ext.AppLog, int64, error) {
+	var where []string
+	var args []any
+
+	if f.SpanID != "" {
+		where = append(where, "span_id = ?")
+		args = append(args, f.SpanID)
+	}
+	if f.TraceID != "" {
+		where = append(where, "trace_id = ?")
+		args = append(args, f.TraceID)
+	}
+	if f.Service != "" {
+		where = append(where, "service = ?")
+		args = append(args, f.Service)
+	}
+	if !f.Since.IsZero() {
+		where = append(where, "ts >= ?")
+		args = append(args, f.Since.UnixMilli())
+	}
+	if !f.Until.IsZero() {
+		where = append(where, "ts <= ?")
+		args = append(args, f.Until.UnixMilli())
+	}
+	if f.Search != "" {
+		// position() rather than LIKE: nothing to escape, so a search for
+		// "100%" cannot become a wildcard that matches every line.
+		where = append(where, "position(message, ?) > 0")
+		args = append(args, f.Search)
+	}
+	// By severity rank, not lexically: "error" sorts before "warn" as text and
+	// after it as severity, so a lexical comparison returns the wrong set.
+	if f.LevelMin != "" {
+		min := ext.LevelRank(f.LevelMin)
+		var keep []string
+		for _, name := range []string{"trace", "debug", "info", "warn", "error", "fatal"} {
+			if ext.LevelRank(name) >= min {
+				keep = append(keep, "?")
+				args = append(args, name)
+			}
+		}
+		// An unrecognised level outranks every known one and is always kept.
+		clause := "level NOT IN ('trace','debug','info','warn','error','fatal')"
+		if len(keep) > 0 {
+			clause = "level IN (" + strings.Join(keep, ",") + ") OR " + clause
+		}
+		where = append(where, "("+clause+")")
+	}
+
+	clause := ""
+	if len(where) > 0 {
+		clause = " WHERE " + strings.Join(where, " AND ")
+	}
+
+	var total int64
+	if err := s.db.QueryRowContext(ctx, `SELECT count() FROM app_logs`+clause, args...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 200
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, ts, service, trace_id, span_id, level, message, fields, source, truncated
+		 FROM app_logs`+clause+` ORDER BY ts ASC, id ASC LIMIT ? OFFSET ?`,
+		append(args, limit, f.Offset)...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var out []ext.AppLog
+	for rows.Next() {
+		var (
+			l         ext.AppLog
+			ts        int64
+			fields    string
+			truncated uint8
+		)
+		if err := rows.Scan(&l.ID, &ts, &l.Service, &l.TraceID, &l.SpanID,
+			&l.Level, &l.Message, &fields, &l.Source, &truncated); err != nil {
+			return nil, 0, err
+		}
+		l.Time = time.UnixMilli(ts).UTC()
+		l.Truncated = truncated != 0
+		if fields != "" {
+			if err := json.Unmarshal([]byte(fields), &l.Fields); err != nil {
+				l.Fields = map[string]string{"_unparsable_fields": fields}
+			}
+		}
+		out = append(out, l)
+	}
+	return out, total, rows.Err()
+}
+
+func (s *ClickHouseStore) CountAppLogs(ctx context.Context) (int64, error) {
+	var n int64
+	err := s.db.QueryRowContext(ctx, `SELECT count() FROM app_logs`).Scan(&n)
+	return n, err
+}
+
+// AppLogStats aggregates in the database rather than by counting rows in the
+// caller — a summary of the first page is wrong at exactly the volumes where a
+// summary starts to matter.
+func (s *ClickHouseStore) AppLogStats(ctx context.Context, since time.Time) (*ext.AppLogSummary, error) {
+	out := &ext.AppLogSummary{ByLevel: map[string]int64{}, ByService: map[string]int64{}}
+	cutoff := since.UnixMilli()
+
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT count(), uniqExact(span_id) FROM app_logs WHERE ts >= ?`, cutoff,
+	).Scan(&out.Total, &out.SpansWithLogs); err != nil {
+		return nil, err
+	}
+
+	for _, g := range []struct {
+		col  string
+		into map[string]int64
+	}{
+		{"level", out.ByLevel},
+		{"service", out.ByService},
+	} {
+		rows, err := s.db.QueryContext(ctx,
+			`SELECT `+g.col+`, count() FROM app_logs WHERE ts >= ? GROUP BY `+g.col, cutoff)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var key string
+			var n int64
+			if err := rows.Scan(&key, &n); err != nil {
+				rows.Close()
+				return nil, err
+			}
+			g.into[key] = n
+		}
+		err = rows.Err()
+		rows.Close()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// PruneAppLogsBefore enforces the app-log retention horizon.
+//
+// mutations_sync=2 for the same reason the record path uses it: an unsynchronised
+// ALTER ... DELETE returns before the data is gone, so retention would report
+// success while the rows were still readable.
+func (s *ClickHouseStore) PruneAppLogsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	ms := cutoff.UnixMilli()
+	var n int64
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT count() FROM app_logs WHERE ts < ?`, ms).Scan(&n); err != nil {
+		return 0, err
+	}
+	if n == 0 {
+		return 0, nil
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`ALTER TABLE app_logs DELETE WHERE ts < ?`+syncMutations, ms); err != nil {
+		return 0, err
+	}
+	return n, nil
+}

--- a/internal/store/conformance_test.go
+++ b/internal/store/conformance_test.go
@@ -49,8 +49,10 @@ func drivers(t *testing.T) []driverFactory {
 				if err != nil {
 					t.Fatalf("open postgres: %v", err)
 				}
-				// Each test starts from a clean table.
-				if _, err := s.db.Exec(`TRUNCATE logs RESTART IDENTITY`); err != nil {
+				// Each test starts from clean tables. Both of them: the suite
+				// makes exact count assertions, and a leftover app log line
+				// fails an assertion about records for no obvious reason.
+				if _, err := s.db.Exec(`TRUNCATE logs, app_logs RESTART IDENTITY`); err != nil {
 					t.Fatalf("truncate: %v", err)
 				}
 				t.Cleanup(func() { s.Close() })
@@ -66,10 +68,12 @@ func drivers(t *testing.T) []driverFactory {
 				if err != nil {
 					t.Fatalf("open clickhouse: %v", err)
 				}
-				// Each test starts from a clean table. TRUNCATE is synchronous
+				// Each test starts from clean tables. TRUNCATE is synchronous
 				// for MergeTree, unlike ALTER ... DELETE.
-				if _, err := s.db.Exec(`TRUNCATE TABLE logs`); err != nil {
-					t.Fatalf("truncate: %v", err)
+				for _, tbl := range []string{"logs", "app_logs"} {
+					if _, err := s.db.Exec(`TRUNCATE TABLE IF EXISTS ` + tbl); err != nil {
+						t.Fatalf("truncate %s: %v", tbl, err)
+					}
 				}
 				t.Cleanup(func() { s.Close() })
 				return s

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -68,6 +68,27 @@ CREATE INDEX IF NOT EXISTS idx_logs_labels  ON logs USING gin(labels);
 CREATE INDEX IF NOT EXISTS idx_logs_rules   ON logs USING gin(matched_rules);
 -- Same reasoning as SQLite: percentile_cont sorts within each route group.
 CREATE INDEX IF NOT EXISTS idx_logs_route_duration ON logs(route, method, duration_ms);
+
+-- Application log lines, correlated to a span. A separate table, not more
+-- columns: many lines per exchange is a different cardinality entirely, and
+-- they want their own retention horizon.
+CREATE TABLE IF NOT EXISTS app_logs (
+	id        BIGSERIAL PRIMARY KEY,
+	ts        BIGINT NOT NULL,
+	service   TEXT NOT NULL DEFAULT '',
+	trace_id  TEXT NOT NULL DEFAULT '',
+	span_id   TEXT NOT NULL DEFAULT '',
+	level     TEXT NOT NULL DEFAULT '',
+	message   TEXT NOT NULL DEFAULT '',
+	fields    JSONB NOT NULL DEFAULT '{}'::jsonb,
+	source    TEXT NOT NULL DEFAULT '',
+	truncated BOOLEAN NOT NULL DEFAULT false
+);
+-- "what did this request log" is the point, and it is a point lookup over the
+-- fastest-growing table in the store.
+CREATE INDEX IF NOT EXISTS idx_app_logs_span  ON app_logs(span_id, ts);
+CREATE INDEX IF NOT EXISTS idx_app_logs_trace ON app_logs(trace_id, ts);
+CREATE INDEX IF NOT EXISTS idx_app_logs_ts    ON app_logs(ts);
 `
 
 // NewPostgres opens (and migrates) a Postgres-backed store. dsn is a standard
@@ -441,11 +462,44 @@ func (s *PostgresStore) Purge(ctx context.Context, label, value string, before t
 		query += ` AND ts < $3`
 		args = append(args, before.UnixMilli())
 	}
-	res, err := s.db.ExecContext(ctx, query, args...)
+
+	// Erasure has to take the application log lines with it. A tenant's
+	// requests deleted while the lines those requests wrote survive is not
+	// erasure — and a log is the likelier place for the personal data to be
+	// sitting, because nobody redacts a log line as carefully as a payload.
+	//
+	// One transaction: a partial erasure that reports success is worse than a
+	// failed one, because nobody comes back to it.
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, err
 	}
-	return res.RowsAffected()
+	defer tx.Rollback()
+
+	logQuery := `DELETE FROM app_logs WHERE trace_id IN (
+		SELECT trace_id FROM logs WHERE labels->>$1 = $2 AND trace_id <> ''`
+	if !before.IsZero() {
+		logQuery += ` AND ts < $3`
+	}
+	logQuery += `)`
+	if _, err := tx.ExecContext(ctx, logQuery, args...); err != nil {
+		return 0, fmt.Errorf("purge app logs: %w", err)
+	}
+
+	res, err := tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	// Deliberately the RECORD count: the caller asked how many requests were
+	// erased, and inflating it with log lines would misreport the answer.
+	return n, nil
 }
 
 func (s *PostgresStore) Close() error { return s.db.Close() }

--- a/internal/store/postgres_applog.go
+++ b/internal/store/postgres_applog.go
@@ -1,0 +1,218 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dwarka-prasad/optictrace/ext"
+)
+
+// PostgresStore implements ext.AppLogStore. Compile-time, because this file
+// existing but not satisfying the interface would surface at runtime as
+// "app logs unsupported", which looks like a config mistake.
+var _ ext.AppLogStore = (*PostgresStore)(nil)
+
+// SaveAppLogs writes a batch in one round trip.
+//
+// Batching is the point: application logs arrive at many lines per request,
+// and a statement per line makes the store the slowest part of the system.
+func (s *PostgresStore) SaveAppLogs(ctx context.Context, lines []ext.AppLog) error {
+	if len(lines) == 0 {
+		return nil
+	}
+
+	// One multi-row INSERT rather than a prepared statement in a loop: the
+	// round trips dominate, not the parsing.
+	var b strings.Builder
+	b.WriteString(`INSERT INTO app_logs (ts, service, trace_id, span_id, level, message, fields, source, truncated) VALUES `)
+	args := make([]any, 0, len(lines)*9)
+	for i := range lines {
+		l := &lines[i]
+		if l.Time.IsZero() {
+			l.Time = time.Now()
+		}
+		fields := "{}"
+		if len(l.Fields) > 0 {
+			raw, err := json.Marshal(l.Fields)
+			if err != nil {
+				return fmt.Errorf("marshal fields: %w", err)
+			}
+			fields = string(raw)
+		}
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		n := i * 9
+		b.WriteString("($" + strconv.Itoa(n+1) + ",$" + strconv.Itoa(n+2) + ",$" + strconv.Itoa(n+3) +
+			",$" + strconv.Itoa(n+4) + ",$" + strconv.Itoa(n+5) + ",$" + strconv.Itoa(n+6) +
+			",$" + strconv.Itoa(n+7) + "::jsonb,$" + strconv.Itoa(n+8) + ",$" + strconv.Itoa(n+9) + ")")
+		args = append(args, l.Time.UnixMilli(), l.Service, l.TraceID, l.SpanID,
+			l.Level, l.Message, fields, l.Source, l.Truncated)
+	}
+	_, err := s.db.ExecContext(ctx, b.String(), args...)
+	return err
+}
+
+// QueryAppLogs returns matching lines oldest-first: reading what a request did
+// means reading it in the order it happened.
+func (s *PostgresStore) QueryAppLogs(ctx context.Context, f ext.AppLogFilter) ([]ext.AppLog, int64, error) {
+	var where []string
+	var args []any
+	arg := func(v any) string {
+		args = append(args, v)
+		return "$" + strconv.Itoa(len(args))
+	}
+
+	if f.SpanID != "" {
+		where = append(where, "span_id = "+arg(f.SpanID))
+	}
+	if f.TraceID != "" {
+		where = append(where, "trace_id = "+arg(f.TraceID))
+	}
+	if f.Service != "" {
+		where = append(where, "service = "+arg(f.Service))
+	}
+	if !f.Since.IsZero() {
+		where = append(where, "ts >= "+arg(f.Since.UnixMilli()))
+	}
+	if !f.Until.IsZero() {
+		where = append(where, "ts <= "+arg(f.Until.UnixMilli()))
+	}
+	if f.Search != "" {
+		// position() rather than LIKE: no metacharacters to escape, so a
+		// search for "100%" cannot become a wildcard matching every line.
+		where = append(where, "position("+arg(f.Search)+" in message) > 0")
+	}
+	// Level is compared by RANK, not lexically — "error" sorts before "warn"
+	// as text and after it as severity. Expanding the minimum into its set
+	// keeps the two drivers agreeing on what "at least warn" means.
+	if f.LevelMin != "" {
+		min := ext.LevelRank(f.LevelMin)
+		var keep []string
+		for _, name := range []string{"trace", "debug", "info", "warn", "error", "fatal"} {
+			if ext.LevelRank(name) >= min {
+				keep = append(keep, arg(name))
+			}
+		}
+		// An unrecognised level outranks every known one and is always kept: a
+		// filter must never be the reason a custom "panic" vanishes.
+		clause := "level NOT IN ('trace','debug','info','warn','error','fatal')"
+		if len(keep) > 0 {
+			clause = "level IN (" + strings.Join(keep, ",") + ") OR " + clause
+		}
+		where = append(where, "("+clause+")")
+	}
+
+	clause := ""
+	if len(where) > 0 {
+		clause = " WHERE " + strings.Join(where, " AND ")
+	}
+
+	var total int64
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM app_logs`+clause, args...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 200
+	}
+	q := `SELECT id, ts, service, trace_id, span_id, level, message, fields, source, truncated
+		FROM app_logs` + clause + ` ORDER BY ts ASC, id ASC LIMIT ` + arg(limit) + ` OFFSET ` + arg(f.Offset)
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var out []ext.AppLog
+	for rows.Next() {
+		var (
+			l      ext.AppLog
+			ts     int64
+			fields []byte
+		)
+		if err := rows.Scan(&l.ID, &ts, &l.Service, &l.TraceID, &l.SpanID,
+			&l.Level, &l.Message, &fields, &l.Source, &l.Truncated); err != nil {
+			return nil, 0, err
+		}
+		l.Time = time.UnixMilli(ts).UTC()
+		if len(fields) > 0 {
+			if err := json.Unmarshal(fields, &l.Fields); err != nil {
+				// A row that will not unmarshal is worth seeing, but it must
+				// not fail the whole query: the message is still readable and
+				// is usually what someone came for.
+				l.Fields = map[string]string{"_unparsable_fields": string(fields)}
+			}
+			if len(l.Fields) == 0 {
+				l.Fields = nil
+			}
+		}
+		out = append(out, l)
+	}
+	return out, total, rows.Err()
+}
+
+func (s *PostgresStore) CountAppLogs(ctx context.Context) (int64, error) {
+	var n int64
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM app_logs`).Scan(&n)
+	return n, err
+}
+
+// AppLogStats aggregates in the database rather than by counting rows in the
+// caller: a dashboard that summarises the first page and calls it a total is
+// quietly lying at exactly the volumes where the summary starts to matter.
+func (s *PostgresStore) AppLogStats(ctx context.Context, since time.Time) (*ext.AppLogSummary, error) {
+	out := &ext.AppLogSummary{ByLevel: map[string]int64{}, ByService: map[string]int64{}}
+	cutoff := since.UnixMilli()
+
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*), COUNT(DISTINCT span_id) FROM app_logs WHERE ts >= $1`, cutoff,
+	).Scan(&out.Total, &out.SpansWithLogs); err != nil {
+		return nil, err
+	}
+
+	for _, g := range []struct {
+		col  string
+		into map[string]int64
+	}{
+		{"level", out.ByLevel},
+		{"service", out.ByService},
+	} {
+		rows, err := s.db.QueryContext(ctx,
+			`SELECT `+g.col+`, COUNT(*) FROM app_logs WHERE ts >= $1 GROUP BY `+g.col, cutoff)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var key string
+			var n int64
+			if err := rows.Scan(&key, &n); err != nil {
+				rows.Close()
+				return nil, err
+			}
+			g.into[key] = n
+		}
+		err = rows.Err()
+		rows.Close()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// PruneAppLogsBefore enforces the app-log retention horizon, which is separate
+// from the record horizon because the volumes differ by orders of magnitude.
+func (s *PostgresStore) PruneAppLogsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM app_logs WHERE ts < $1`, cutoff.UnixMilli())
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}


### PR DESCRIPTION
The three correctness gaps left open by the app-logs work.

## 1. A documented contract that wasn't enforced

`ext/applog.go` told driver authors *"ext/exttest asserts this"* about `Purge` deleting the log lines belonging to the records it removes. **It didn't** — the test lived in `internal/store`, covering SQLite and nothing else. A third-party driver could implement `Store` and `AppLogStore`, pass the entire conformance suite, and still leave a purged tenant's log lines behind.

That rule is the one part of the contract that can't be inferred from the interface signatures, which is exactly why it needs asserting rather than documenting. And a log line is the *likelier* place for the personal data to be sitting, because nobody redacts a log as carefully as a payload.

`ext/exttest` now covers app logs — round-trip, ordering, level-by-severity, stats, retention, and erasure. The sub-tests **skip** when a driver has no app-log support, so the interface stays genuinely optional; `examples/memstore` passes untouched, which is the proof.

## 2. Only SQLite could store them

Postgres and ClickHouse answered 501, so the feature was missing on exactly the multi-node deployments most likely to want it. Both now implement the full interface and both erase log lines with their records.

**ClickHouse deletes the lines first**, deliberately: there's no transaction across the two mutations, and if the second delete fails the caller sees an error and retries — which is safe. The other order could report failure having already removed the records, leaving orphaned lines nothing will ever match again.

Level filtering compares by **severity rank** in both, not lexically — `error` sorts before `warn` as text and after it as severity. Search uses `position()` rather than `LIKE`, so looking for `100%` can't become a wildcard matching every line.

## 3. The leak detector couldn't see the riskier surface

`optictrace scan` read payloads but not log lines. The gap was demonstrable:

```
$ optictrace scan            # before: record body is {"amount":42}
✓ scanned 1 record(s) over 1h — no sensitive values found outside your rules

$ optictrace scan            # after
⚠ [high] credit-card in payments log:debug → app_log.message
    sample 41••••••••••••11
    fix: telemetry:
           app_logs:
             redact:
               patterns: ['<a regex matching this value>']

scanned 1 record(s) and 2 log line(s): 0 critical, 2 high, 0 medium
```

The suggested fix is a pattern or field name under `app_logs.redact` — suggesting `redact.json_fields` would be advice that cannot work on free text. Log-line findings group by service and level, since that's what a line has. Both the CLI and `GET /api/scan` report the lines read alongside the record count: *0 findings over zero lines* means something very different from *0 findings over forty thousand*.

## Verification

Run against **real** databases, not mocks:

- Postgres 16 and ClickHouse 24.3 in Docker — **45 conformance sub-tests, 0 failures** across sqlite / postgres / clickhouse
- **Each driver's purge broken in turn** to confirm the new erasure test actually fails; it does, on all three
- `examples/memstore` still passes, skipping the optional sub-tests
- `make lint`, `make test-all`, `-race` on store / scan / admin, 15/15 rule tests

## Still open

- App-log ingestion is endpoint-only — no stdout/file tailer
- Redaction is global (`telemetry.app_logs.redact`), not per-rule
- `review` still doesn't read log lines (only `scan` does)
- FastAPI lacks tail-based sampling; the Java SDK is `jakarta`-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
