### PR TITLE
feat: close the app-log feature gaps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# The build context is uploaded to the daemon in full, so anything not needed to
+# BUILD belongs here. Local dependency and artifact trees are the bulk of it —
+# and node_modules is also actively harmful: it can shadow the clean install the
+# ui stage does, with a tree built for a different architecture.
+.git
+.github
+
+# Dependency and build output
+node_modules
+ui/node_modules
+ui/.next
+ui/out
+bin
+dist
+sdks/express/node_modules
+
+# Local stores and run artifacts — telemetry from someone's laptop has no
+# business inside a published image.
+*.db
+*.db-wal
+*.db-shm
+examples/**/.run
+examples/**/.venv
+examples/python-shop/shop.db*
+__pycache__
+.venv
+
+# Java build output
+sdks/java/target
+
+# Editor and OS noise
+.DS_Store
+*.swp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,19 @@ jobs:
           mvn -q -B compile
           javac -d target/test-classes -cp "target/classes:$(cat cp.txt)"             src/test/java/io/github/dwarkaprasad/optictrace/SelfTest.java
           java -cp "target/classes:target/test-classes:$(cat cp.txt)"             io.github.dwarkaprasad.optictrace.SelfTest
+      - name: Java SDK tests (javax variant)
+        working-directory: sdks/java
+        # The javax variant is GENERATED from the jakarta sources, so it has to
+        # be RUN and not merely compiled — a generated copy nobody executes is
+        # the copy that breaks.
+        run: |
+          ./scripts/gen-javax.sh target/javax-src
+          mvn -q -B dependency:get -Dartifact=javax.servlet:javax.servlet-api:4.0.1
+          JAVAX=$(find ~/.m2 -name 'javax.servlet-api-4.0.1.jar' | head -1)
+          CP="$(tr ':' '\n' < cp.txt | grep -v 'jakarta.servlet' | paste -sd:):$JAVAX"
+          mkdir -p target/javax-classes
+          javac -d target/javax-classes -cp "$CP" target/javax-src/io/github/dwarkaprasad/optictrace/*.java
+          java -cp "target/javax-classes:$CP" io.github.dwarkaprasad.optictrace.SelfTest
 
   assets:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Versions `0.4.0`–`0.6.0` were development milestones that were never tagged;
 
 ### Added
 
+- **Collect the logs an application already writes.** `optictrace run -exec "python app.py"` captures a child process's stdout and stderr, and `telemetry.app_logs.sources` tails files with rotation followed. Ingestion previously required every service to POST its lines, which means touching code in the services whose logs you most want — usually the ones nobody wants to modify.
+
+  Collected output is echoed through untouched: collecting a service's logs must not stop them reaching wherever its operators already read them, and this process does not get to rewrite another program's output stream. Tailing starts at the END of an existing file, because replaying a large log on every restart floods the store with history nobody asked for and retention then discards the recent lines that were actually wanted. A text source with no `span_pattern` warns at startup, since every one of its lines would be dropped as an orphan.
+
+- **Per-rule log policy.** A `logs:` block on a rule tightens `telemetry.app_logs` for the routes it matches — a stricter level floor, a lower line cap, extra redaction, or `drop: true`. It can only ever tighten, which is precisely what makes it safe to resolve from a route the producer reports without verifying it: the worst a lying or silent client can do is land on the global floor. `logs:` with the feature disabled is now a config error rather than dead config.
+
+- **`optictrace review` reads application log lines**, the way `scan` already did, and prints how many — "no leaks" over zero lines means something very different from no leaks over forty thousand.
+
+- **A generated `javax.servlet` variant of the Java SDK** for Spring Boot 2 and Tomcat 9. Generated rather than maintained as a second copy, because two copies of the same engine drift and the copy nobody runs is the one that drifts; CI compiles *and runs* the full suite against it.
+
 - **Postgres and ClickHouse store application logs.** Previously SQLite only, so the feature was unavailable on exactly the multi-node deployments most likely to want it. Both implement the full `ext.AppLogStore` and both erase log lines together with the records a `purge` removes — ClickHouse deletes the lines first, because it has no transaction across the two mutations and a retry is safe while an orphaned line nothing can match again is not.
 
 - **`ext/exttest` asserts the app-log contract**, including the erasure rule that `ext/applog.go` documents. That rule cannot be inferred from the interface signatures: a driver can implement `Store` and `AppLogStore` perfectly and still leave a purged tenant's log lines behind, and a log is the likelier place for the personal data to be sitting. The sub-tests skip for a driver without app-log support, so the interface stays genuinely optional. Verified by breaking each driver's purge in turn and watching the suite fail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versions `0.4.0`–`0.6.0` were development milestones that were never tagged;
 
 ### Added
 
+- **Exporters receive application log lines.** `scan` and `review` already read them; the file, webhook, command and OTLP exporters shipped records only, so anyone using the file exporter as their audit trail was missing the surface most likely to carry the personal data. `ext.AppLogExporter` is an OPTIONAL companion to `ext.Exporter`, discovered by type assertion for the same reason `AppLogStore` is separate from `Store` — adding a method to a published interface breaks every third-party exporter at compile time. An exporter without it still receives records, and says so at startup rather than leaving it to be discovered.
+
+  Both streams go to ONE file, with the log lines tagged `kind: app_log`. A consumer reading an audit trail wants the request and the lines it wrote in one place and in order; splitting them means reassembling by timestamp, which is the correlation problem this feature exists to avoid. Records stay untagged so existing consumers keep parsing them.
+
 - **Collect the logs an application already writes.** `optictrace run -exec "python app.py"` captures a child process's stdout and stderr, and `telemetry.app_logs.sources` tails files with rotation followed. Ingestion previously required every service to POST its lines, which means touching code in the services whose logs you most want — usually the ones nobody wants to modify.
 
   Collected output is echoed through untouched: collecting a service's logs must not stop them reaching wherever its operators already read them, and this process does not get to rewrite another program's output stream. Tailing starts at the END of an existing file, because replaying a large log on every restart floods the store with history nobody asked for and retention then discards the recent lines that were actually wanted. A text source with no `span_pattern` warns at startup, since every one of its lines would be dropped as an orphan.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,22 +4,39 @@
 #   Stage 1: build the Next.js dashboard (static export)
 #   Stage 2: build the Go agent (pure Go, CGO disabled — modernc SQLite)
 #   Stage 3: minimal runtime image
+#
+# Both build stages are pinned to $BUILDPLATFORM and cross-compile to
+# $TARGETARCH. Without those pins, buildx builds every stage once per target
+# platform — so a `--platform linux/amd64,linux/arm64` build ran the whole
+# Next.js compile a second time under QEMU emulation, which took this from
+# minutes to the better part of an hour and eventually never finished at all.
+#
+# Nothing here needs emulation: the dashboard is a static export and is
+# architecture-independent, and the agent is pure Go with CGO off, so GOARCH is
+# all it takes to target another architecture.
 # ============================================================================
 
-FROM node:22-alpine AS ui
+FROM --platform=$BUILDPLATFORM node:22-alpine AS ui
 WORKDIR /src/ui
 COPY ui/package.json ui/package-lock.json* ./
-RUN npm install --no-audit --no-fund
+# `npm ci` when a lockfile is present: an image build must be reproducible, and
+# `npm install` is free to resolve a different tree than the one that was tested.
+RUN if [ -f package-lock.json ]; then npm ci --no-audit --no-fund; \
+    else npm install --no-audit --no-fund; fi
 COPY ui/ .
-RUN npm run build   # -> /src/ui/out
+RUN npm run build   # -> /src/ui/out (static, architecture-independent)
 
-FROM golang:1.25-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 ARG VERSION=docker
-RUN CGO_ENABLED=0 go build -trimpath \
+# Supplied by buildx for each requested platform.
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+    go build -trimpath \
       -ldflags "-s -w -X main.version=${VERSION}" \
       -o /out/optictrace ./cmd/optictrace
 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,13 @@ bench: ## Measure interceptor overhead vs a bare handler
 demo: dev ## Alias for `make dev`
 
 docker: ## Build the production image
-	docker build -t optictrace:dev .
+	# BuildKit is required: the build stages are pinned to $$BUILDPLATFORM so a
+	# multi-arch build cross-compiles instead of emulating, and the classic
+	# builder does not define it.
+	DOCKER_BUILDKIT=1 docker build -t optictrace:dev .
+
+docker-multiarch: ## Build for amd64 + arm64 exactly as the release does
+	docker buildx build --platform linux/amd64,linux/arm64 -t optictrace:dev .
 
 clean: ## Remove build output and the local store
 	rm -rf bin ui/out ui/.next optictrace.db*

--- a/README.md
+++ b/README.md
@@ -987,6 +987,28 @@ OpticTrace already hands your app the span: the `traceparent` on the forwarded
 request carries the span id it recorded. Ship your log lines with that id and
 they are filed under the exact request that produced them.
 
+You can also collect what the application **already writes**, with no code
+change at all — which matters, because the services whose logs you most want
+are usually the ones nobody wants to modify:
+
+```bash
+optictrace run -config optic.yaml -exec "python app.py"     # its stdout/stderr
+```
+
+```yaml
+telemetry:
+  app_logs:
+    sources:
+      - { type: file, path: /var/log/app.jsonl }   # rotation followed
+```
+
+Collected output is **echoed through untouched**: collecting a service's logs
+must not stop them reaching wherever its operators already read them. Tailing
+starts at the end of an existing file, because replaying a large log on every
+restart floods the store with history nobody asked for.
+
+Or post them explicitly:
+
 ```bash
 curl -X POST localhost:9095/api/applogs/ingest -d '[
   {"trace_id":"4bf92f35…","span_id":"512227e3…","level":"info","message":"charge received"},
@@ -1044,7 +1066,13 @@ Three consequences worth knowing before you turn it on:
   `optictrace_app_logs_dropped_total{reason="orphan"}` — data discarded
   silently is data nobody knows they are missing. Set `drop_orphans: false` to
   keep them unattributed.
-- **`optictrace scan` reads them too.** A payload is structured and can be
+- **Policy can narrow per route.** `telemetry.app_logs` is the floor; a
+  `logs:` block on a rule tightens it — a stricter level, a lower line cap,
+  extra redaction, or `drop: true` for a route whose output nothing can
+  pattern-match safely. It can only ever *tighten*, which is what makes it safe
+  to key on a route the producer reports without verifying it: the worst a
+  silent or lying client can do is land on the global floor.
+- **`optictrace scan` and `review` read them too.** A payload is structured and can be
   masked by JSON path; a log line is free text. A leak detector that only reads
   payloads looks where the data is easiest to protect rather than where it
   escapes, so scan reports on both and the suggested fix differs — a pattern or
@@ -1219,13 +1247,15 @@ telemetry:
 | Labels — all six sources, `\|regex` capture | ✅ | ✅ | ✅ | ✅ |
 | Meters | ✅ | ✅ | ✅ | ✅ |
 | Trace correlation | ✅ | ✅ | ✅ | ✅ |
-| Tail-based `keep_errors` / `keep_slower_than` | ✅ | — | ✅ | ✅ |
+| Tail-based `keep_errors` / `keep_slower_than` | ✅ | ✅ | ✅ | ✅ |
 | Application logs | ✅ | ✅ | ✅ | ✅ |
 
 <sub>Gin and net/http route through the same Go interceptor as the proxy, so
 they inherit everything it does. Every SDK's suite can assert that a **live
 agent accepts** what it produces — set `OPTIC_AGENT_URL` and run it that way in
-CI, because offline tests cannot catch a record the agent rejects.</sub>
+CI, because offline tests cannot catch a record the agent rejects. The Java SDK
+also ships a generated `javax.servlet` variant for Spring Boot 2, compiled *and
+run* in CI.</sub>
 
 ### Node.js / Express
 

--- a/applog.go
+++ b/applog.go
@@ -132,6 +132,11 @@ func (h *LogHandler) Handle(ctx context.Context, r slog.Record) error {
 	if c, ok := tracectx.FromContext(ctx); ok {
 		line["trace_id"] = c.TraceID
 		line["span_id"] = c.SpanID
+		if c.Route != "" {
+			// Lets a per-rule `logs:` block apply to this line. Safe to send
+			// because such a block can only tighten the global policy.
+			line["route"] = c.Route
+		}
 	}
 
 	fields := map[string]string{}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -337,6 +337,12 @@ func reviewChanges(a reviewArgs) {
 	}
 
 	opts := review.Options{Records: records, Head: headCfg, Window: a.window.String()}
+	// Application log lines from the same window, when the local store has
+	// them. A remote or file-based review has records only, which is reported
+	// rather than hidden: the report prints how many lines it read.
+	if a.from == "" && a.fromFile == "" {
+		opts.AppLogs = loadAppLogs(headCfg, a.window)
+	}
 	if a.baseConfig != "" {
 		// A missing base config is not fatal: on the first PR that adds
 		// optic.yaml there is nothing to diff against, and failing there
@@ -471,6 +477,40 @@ func scannedSummary(r *scan.Report) string {
 // scanAppLogs feeds stored application log lines to the scanner. A store
 // driver without app-log support, or a config with the feature off, simply
 // contributes nothing — this is an optional surface, not a required one.
+// loadAppLogs reads stored application log lines for a window. Returns nothing
+// when the feature is off or the driver has no app-log support — this is an
+// optional surface, not a required one.
+func loadAppLogs(cfg *config.Config, window time.Duration) []ext.AppLog {
+	if cfg == nil || cfg.Telemetry.AppLogs == nil || !cfg.Telemetry.AppLogs.Enabled {
+		return nil
+	}
+	st, err := openStore(&cfg.Telemetry.Store)
+	if err != nil {
+		return nil
+	}
+	defer st.Close()
+	als, ok := st.(store.AppLogStore)
+	if !ok {
+		return nil
+	}
+	var out []ext.AppLog
+	limit := store.AnalysisLimit(cfg.Telemetry.Store.AnalysisMaxRows)
+	since := time.Now().Add(-window)
+	for len(out) < limit {
+		lines, total, err := als.QueryAppLogs(context.Background(), store.AppLogFilter{
+			Since: since, Limit: 500, Offset: len(out),
+		})
+		if err != nil || len(lines) == 0 {
+			break
+		}
+		out = append(out, lines...)
+		if int64(len(out)) >= total {
+			break
+		}
+	}
+	return out
+}
+
 func scanAppLogs(sc *scan.Scanner, cfg *config.Config, window time.Duration) {
 	if cfg == nil || cfg.Telemetry.AppLogs == nil || !cfg.Telemetry.AppLogs.Enabled {
 		return
@@ -824,6 +864,12 @@ func run(configPath, uiDir string) {
 	appLogs, err := applog.New(cfg.Telemetry.AppLogs)
 	if err != nil {
 		logger.Error("invalid app-log policy", "error", err)
+		os.Exit(1)
+	}
+	// Per-rule `logs:` blocks tighten the global policy for the routes they
+	// match. Compiled here rather than per line, and only ever narrowing.
+	if err := appLogs.WithRules(cfg.Rules); err != nil {
+		logger.Error("invalid per-rule app-log policy", "error", err)
 		os.Exit(1)
 	}
 	var appLogStore store.AppLogStore

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -35,6 +35,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strings"
@@ -81,6 +82,7 @@ func Run(args []string, ver string) {
 	fs := flag.NewFlagSet(cmd, flag.ExitOnError)
 	configPath := fs.String("config", "optic.yaml", "path to optic.yaml")
 	uiDir := fs.String("ui", "ui/out", "static dashboard directory (optional)")
+	execCmd := fs.String("exec", "", "run: start this command and collect its stdout/stderr as application logs")
 	specPath := fs.String("spec", "", "OpenAPI spec file (check/mock/sdk)")
 	outPath := fs.String("out", "", "output file (spec/sdk); default stdout")
 	window := fs.Duration("window", 24*time.Hour, "traffic window to analyze (spec/check)")
@@ -107,7 +109,7 @@ func Run(args []string, ver string) {
 
 	switch cmd {
 	case "run":
-		run(*configPath, *uiDir)
+		run(*configPath, *uiDir, *execCmd)
 	case "validate":
 		validate(*configPath)
 	case "spec":
@@ -543,6 +545,82 @@ func scanAppLogs(sc *scan.Scanner, cfg *config.Config, window time.Duration) {
 	}
 }
 
+// hasStdoutSource reports whether the config already declares one, so -exec
+// does not add a duplicate.
+func hasStdoutSource(sources []config.AppLogSource) bool {
+	for _, s := range sources {
+		if s.Type == "stdout" {
+			return true
+		}
+	}
+	return false
+}
+
+// startChild runs a command with `sh -c`, collecting its output.
+//
+// The output is ALSO echoed to this process's own stdout/stderr: collecting a
+// service's logs must not stop them reaching wherever its operators already
+// read them. A collector that silently swallows logs is worse than no
+// collector.
+func startChild(command string, collector *applog.Collector, sources []config.AppLogSource,
+	logger *slog.Logger) <-chan int {
+
+	cmd := exec.Command("sh", "-c", command)
+	cmd.Stdin = os.Stdin
+
+	src := config.AppLogSource{Type: "stdout"}
+	for _, s := range sources {
+		if s.Type == "stdout" {
+			src = s
+			break
+		}
+	}
+
+	if collector == nil {
+		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	} else {
+		outPipe, err := cmd.StdoutPipe()
+		if err != nil {
+			logger.Error("cannot capture child stdout", "error", err)
+			return nil
+		}
+		errPipe, err := cmd.StderrPipe()
+		if err != nil {
+			logger.Error("cannot capture child stderr", "error", err)
+			return nil
+		}
+		go collector.Read(context.Background(), outPipe, src, os.Stdout)
+		go collector.Read(context.Background(), errPipe, src, os.Stderr)
+	}
+
+	if err := cmd.Start(); err != nil {
+		logger.Error("cannot start -exec command", "command", command, "error", err)
+		os.Exit(1)
+	}
+	logger.Info("started child process", "command", command, "pid", cmd.Process.Pid)
+
+	// The child is the reason this agent is running: if it exits, staying up
+	// would leave a proxy in front of nothing. But it must NOT exit from here.
+	// os.Exit in a goroutine skips the shutdown path, and the shutdown path is
+	// what drains collected log lines — so the last lines of a crashing
+	// process, which are the ones worth having, would be lost. Report the code
+	// and let the main loop shut down properly.
+	done := make(chan int, 1)
+	go func() {
+		err := cmd.Wait()
+		code := 0
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			code = ee.ExitCode()
+		} else if err != nil {
+			code = 1
+		}
+		logger.Info("child process exited", "code", code)
+		done <- code
+	}()
+	return done
+}
+
 func loadTraffic(configPath string, window time.Duration) (*config.Config, []store.Record) {
 	cfg, err := config.Load(configPath)
 	if err != nil {
@@ -800,7 +878,7 @@ func resolveUIDir(flagValue string, logger *slog.Logger) string {
 	return ""
 }
 
-func run(configPath, uiDir string) {
+func run(configPath, uiDir, execCmd string) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	uiDir = resolveUIDir(uiDir, logger)
 
@@ -884,6 +962,58 @@ func run(configPath, uiDir string) {
 				"lines will be refused",
 				"driver", cfg.Telemetry.Store.Driver)
 		}
+	}
+
+	// --- application-log collection ---------------------------------------
+	// Sources read what the application already writes, so a service that logs
+	// JSON to stdout needs no code change. Started before the child process so
+	// its first lines are not missed.
+	var logCollector *applog.Collector
+	// Closed when an -exec child exits, carrying its status so this process can
+	// mirror it after shutting down cleanly.
+	var childExit <-chan int
+	if appLogs.Enabled() && appLogStore != nil {
+		cfgSources := cfg.Telemetry.AppLogs.Sources
+		if execCmd != "" && !hasStdoutSource(cfgSources) {
+			// -exec without a declared stdout source is unambiguous: the point
+			// of -exec is to collect that process's output.
+			cfgSources = append(cfgSources, config.AppLogSource{Type: "stdout"})
+		}
+		if len(cfgSources) > 0 {
+			logCollector = applog.NewCollector(appLogs, appLogStore, cfg.Service.Name, logger)
+			if collector != nil {
+				// Same counters as the ingest endpoint, so a drop is visible
+				// however the line arrived.
+				logCollector.OnDrop(func(reason string) { collector.AppLogDropped(reason, 1) })
+				logCollector.OnKeep(collector.AppLogStored)
+			}
+			logCollector.Start(context.Background())
+			for _, src := range cfgSources {
+				// A line with no span is an orphan, and orphans are dropped by
+				// default. For a text source without a span_pattern that is
+				// EVERY line, which looks like a broken collector rather than a
+				// working policy — so say it at startup rather than leaving
+				// someone to find an empty dashboard and a drop counter.
+				if src.Format == "text" && src.SpanPattern == "" && cfg.Telemetry.AppLogs.DropOrphanLines() {
+					logger.Warn("app-log source has format: text with no span_pattern — "+
+						"its lines carry no span, so every one will be dropped as an orphan; "+
+						"set span_pattern, use format: json, or set drop_orphans: false",
+						"path", src.Path, "type", src.Type)
+				}
+				if src.Type == "file" {
+					logger.Info("collecting application logs", "source", "file", "path", src.Path)
+					logCollector.Tail(context.Background(), src)
+				}
+			}
+			if execCmd != "" {
+				childExit = startChild(execCmd, logCollector, cfgSources, logger)
+			}
+		}
+	} else if execCmd != "" {
+		logger.Warn("-exec given but application logs are not collectable — " +
+			"set telemetry.app_logs.enabled and a store driver that supports them; " +
+			"the command will still run, its output only echoed")
+		childExit = startChild(execCmd, nil, nil, logger)
 	}
 
 	// --- output exporters (custom plugins) --------------------------------
@@ -1053,7 +1183,14 @@ func run(configPath, uiDir string) {
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
-	<-stop
+	exitCode := 0
+	select {
+	case <-stop:
+	case code := <-childExit:
+		// Mirror the child's status: a supervisor reads it, and reporting 0 for
+		// a crashed process would make the crash invisible.
+		exitCode = code
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -1061,6 +1198,9 @@ func run(configPath, uiDir string) {
 		_ = proxySrv.Shutdown(ctx)
 	}
 	_ = adminSrv.Shutdown(ctx)
+	if logCollector != nil {
+		logCollector.Close() // drains collected log lines
+	}
 	if writer != nil {
 		_ = writer.Close() // drains the telemetry queue
 	}
@@ -1068,4 +1208,9 @@ func run(configPath, uiDir string) {
 		dispatcher.Shutdown() // flushes exporter batches
 	}
 	logger.Info("optictrace stopped")
+	if exitCode != 0 {
+		// Only after the drain above: the last lines of a crashing process are
+		// the ones worth having.
+		os.Exit(exitCode)
+	}
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1029,6 +1029,18 @@ func run(configPath, uiDir, execCmd string) {
 			os.Exit(1)
 		}
 		logger.Info("exporters started", "count", len(cfg.Telemetry.Exporters))
+
+		// Collected lines fan out to exporters too. Wired here rather than
+		// where the collector is built, because the dispatcher does not exist
+		// until now — an audit trail holding the requests but not the lines
+		// those requests wrote is missing the riskier half.
+		if logCollector != nil && dispatcher.AcceptsAppLogs() {
+			logCollector.OnStored(func(lines []ext.AppLog) {
+				for i := range lines {
+					dispatcher.EnqueueAppLog(&lines[i])
+				}
+			})
+		}
 	}
 
 	// --- proxy ----------------------------------------------------------

--- a/ext/applog.go
+++ b/ext/applog.go
@@ -38,6 +38,15 @@ type AppLog struct {
 	// redacted under the same policy as the message — a token pasted into a
 	// field is exactly as leaked as one in the message text.
 	Fields map[string]string `json:"fields,omitempty"`
+	// Route is the rule pattern the request matched, when the producer knows
+	// it. It lets a per-rule `logs:` block apply to this line.
+	//
+	// Client-supplied and therefore untrusted — which is safe here only
+	// because a per-rule log policy can exclusively TIGHTEN the global one. A
+	// producer that lies about its route, or omits it, gets the global policy:
+	// the floor, never less. If per-rule blocks could ever loosen, this field
+	// would have to be verified instead of trusted.
+	Route string `json:"route,omitempty"`
 	// Source names the producer: an SDK name, or "ingest" for a direct POST.
 	Source string `json:"source,omitempty"`
 	// Truncated reports that Message was cut to the configured byte cap.

--- a/ext/export.go
+++ b/ext/export.go
@@ -28,6 +28,28 @@ type Exporter interface {
 	Close() error
 }
 
+// AppLogExporter is an OPTIONAL companion to Exporter: an exporter may also
+// accept application log lines.
+//
+// Separate interface rather than a second method on Exporter, for the same
+// reason ext.AppLogStore is separate from ext.Store — Exporter is published and
+// implemented outside this module, so adding a method to it would break every
+// third-party exporter at compile time. Detect support with a type assertion:
+//
+//	if ale, ok := myExporter.(ext.AppLogExporter); ok { ... }
+//
+// An exporter without it still receives records; log lines simply do not fan
+// out to it. That is reported at startup rather than left to be discovered,
+// because an audit trail quietly missing the highest-risk surface is worse than
+// one that says it is records-only.
+type AppLogExporter interface {
+	Exporter
+	// ExportAppLogs delivers one batch of governed lines. Same contract as
+	// Export: an error marks the whole batch failed, and ctx is cancelled on
+	// shutdown.
+	ExportAppLogs(ctx context.Context, batch []*AppLog) error
+}
+
 // ExporterOptions is one entry from `telemetry.exporters` as an extension
 // sees it. The core owns batching, so BatchSize/FlushInterval/QueueSize are
 // informational — useful for sizing an internal buffer, not something the

--- a/ext/exttest/conformance.go
+++ b/ext/exttest/conformance.go
@@ -95,6 +95,7 @@ func appLogStore(t *testing.T, s ext.Store) ext.AppLogStore {
 func AppLog(at time.Time, trace, span, level, message string) ext.AppLog {
 	return ext.AppLog{
 		Time: at, Service: "api", TraceID: trace, SpanID: span,
+		Route: "/api/v1/payments/**",
 		Level: level, Message: message, Source: "test",
 		Fields: map[string]string{"k": "v"},
 	}
@@ -139,6 +140,11 @@ func testAppLogs(t *testing.T, open OpenFunc) {
 	}
 	if got[0].TraceID != "t1" || got[0].Level != "info" {
 		t.Errorf("field round-trip: %+v", got[0])
+	}
+	// Route round-trips too. A field that is in the JSON but silently not
+	// persisted is a trap: it reads as empty for reasons nothing explains.
+	if got[0].Route != "/api/v1/payments/**" {
+		t.Errorf("route did not round-trip: %q", got[0].Route)
 	}
 
 	// Trace selects every hop's lines; span selects one hop's.

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -1033,6 +1033,14 @@ func (s *Server) ingestAppLogs(w http.ResponseWriter, r *http.Request) {
 			s.Collector.AppLogDropped(reason, n)
 		}
 	}
+	// Fan out to exporters that accept lines. An audit trail that holds the
+	// requests but not the lines those requests wrote is missing the surface
+	// most likely to carry the personal data.
+	if s.Dispatcher != nil {
+		for i := range kept {
+			s.Dispatcher.EnqueueAppLog(&kept[i])
+		}
+	}
 	writeJSON(w, http.StatusAccepted, map[string]any{
 		"stored":  len(kept),
 		"dropped": dropped,

--- a/internal/applog/applog.go
+++ b/internal/applog/applog.go
@@ -9,12 +9,14 @@
 package applog
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"sync"
 
 	"github.com/dwarka-prasad/optictrace/ext"
 	"github.com/dwarka-prasad/optictrace/internal/config"
+	"github.com/dwarka-prasad/optictrace/internal/engine"
 )
 
 // Defaults chosen so that turning the feature on without tuning it cannot
@@ -31,11 +33,12 @@ const (
 type Reason string
 
 const (
-	ReasonOrphan   Reason = "orphan"   // no span id — belongs to no request
-	ReasonLevel    Reason = "level"    // below level_min
-	ReasonSpanCap  Reason = "span_cap" // span already at max_lines_per_span
-	ReasonDisabled Reason = "disabled" // feature off
-	ReasonEmpty    Reason = "empty"    // nothing left after trimming
+	ReasonOrphan   Reason = "orphan"    // no span id — belongs to no request
+	ReasonLevel    Reason = "level"     // below level_min
+	ReasonSpanCap  Reason = "span_cap"  // span already at max_lines_per_span
+	ReasonDisabled Reason = "disabled"  // feature off
+	ReasonEmpty    Reason = "empty"     // nothing left after trimming
+	ReasonRuleDrop Reason = "rule_drop" // a rule's logs.drop discarded it
 )
 
 // Governor applies the app-log policy. Safe for concurrent use: ingest is an
@@ -59,6 +62,31 @@ type Governor struct {
 	cur      map[string]int
 	prev     map[string]int
 	maxSpans int
+
+	// routes are per-rule overrides, checked in config order so that later
+	// rules win the same way they do everywhere else in optic.yaml.
+	routes []routePolicy
+}
+
+// routePolicy is one rule's compiled `logs:` block.
+type routePolicy struct {
+	name     string
+	segs     []string
+	minRank  int // -1 = no override
+	maxLines int // 0 = no override
+	drop     bool
+	patterns []*regexp.Regexp
+	fields   map[string]bool
+}
+
+// effective is the policy actually applied to one line: the global settings,
+// tightened by every rule whose path matches.
+type effective struct {
+	minRank  int
+	maxLines int
+	drop     bool
+	patterns []*regexp.Regexp
+	fields   map[string]bool
 }
 
 // New builds a Governor from config. A nil or disabled config yields a
@@ -107,6 +135,97 @@ func New(cfg *config.AppLogsCfg) (*Governor, error) {
 	return g, nil
 }
 
+// WithRules compiles the per-rule `logs:` blocks. Call after New.
+//
+// These can only TIGHTEN what New established. A per-route override able to
+// weaken the global policy would make telemetry.app_logs a suggestion rather
+// than a guarantee, and reviewing one file would stop telling you what is
+// enforced.
+func (g *Governor) WithRules(rules []config.Rule) error {
+	for _, r := range rules {
+		if r.Logs == nil {
+			continue
+		}
+		rp := routePolicy{
+			name:     r.Name,
+			segs:     engine.SplitPath(r.Match.Path),
+			minRank:  -1,
+			maxLines: r.Logs.MaxLinesPerSpan,
+			drop:     r.Logs.Drop,
+			fields:   map[string]bool{},
+		}
+		if r.Logs.LevelMin != "" {
+			rp.minRank = ext.LevelRank(r.Logs.LevelMin)
+		}
+		for _, pat := range r.Logs.Redact.Patterns {
+			re, err := regexp.Compile(pat)
+			if err != nil {
+				return fmt.Errorf("rule %q logs.redact: %w", r.Name, err)
+			}
+			rp.patterns = append(rp.patterns, re)
+		}
+		for _, f := range r.Logs.Redact.Fields {
+			rp.fields[strings.ToLower(f)] = true
+		}
+		g.routes = append(g.routes, rp)
+	}
+	return nil
+}
+
+// resolve merges the global policy with every rule matching this line's route.
+//
+// A line with no route — or an unrecognised one — gets the global policy. That
+// is safe precisely because rules only tighten: an unknown route can never end
+// up with less protection than the floor, which is why the route may be taken
+// from the producer without verifying it.
+func (g *Governor) resolve(route string) effective {
+	eff := effective{
+		minRank:  g.minRank,
+		maxLines: g.maxLines,
+		patterns: g.patterns,
+		fields:   g.redactField,
+	}
+	if route == "" || len(g.routes) == 0 {
+		return eff
+	}
+	segs := engine.SplitPath(route)
+	for i := range g.routes {
+		rp := &g.routes[i]
+		// Exact pattern match first: a governed record's Route IS the rule's
+		// glob, so the common case needs no globbing at all.
+		if !(route == "/"+strings.Join(rp.segs, "/") || engine.MatchSegments(rp.segs, segs)) {
+			continue
+		}
+		if rp.drop {
+			eff.drop = true
+		}
+		// Tighten only: a HIGHER floor and a LOWER cap.
+		if rp.minRank > eff.minRank {
+			eff.minRank = rp.minRank
+		}
+		if rp.maxLines > 0 && (eff.maxLines <= 0 || rp.maxLines < eff.maxLines) {
+			eff.maxLines = rp.maxLines
+		}
+		if len(rp.patterns) > 0 {
+			merged := make([]*regexp.Regexp, 0, len(eff.patterns)+len(rp.patterns))
+			merged = append(merged, eff.patterns...)
+			merged = append(merged, rp.patterns...)
+			eff.patterns = merged
+		}
+		if len(rp.fields) > 0 {
+			merged := make(map[string]bool, len(eff.fields)+len(rp.fields))
+			for k := range eff.fields {
+				merged[k] = true
+			}
+			for k := range rp.fields {
+				merged[k] = true
+			}
+			eff.fields = merged
+		}
+	}
+	return eff
+}
+
 // Enabled reports whether app-log ingestion is turned on.
 func (g *Governor) Enabled() bool { return g.enabled }
 
@@ -125,13 +244,21 @@ func (g *Governor) Admit(l *ext.AppLog) (bool, Reason) {
 	if l.SpanID == "" && g.dropOrphans {
 		return false, ReasonOrphan
 	}
-	if g.minRank >= 0 && ext.LevelRank(l.Level) < g.minRank {
+
+	// The route decides which per-rule block applies. Resolved per line rather
+	// than cached per span, because a producer may report a different route on
+	// the same span and the tighter answer must win either way.
+	eff := g.resolve(l.Route)
+	if eff.drop {
+		return false, ReasonRuleDrop
+	}
+	if eff.minRank >= 0 && ext.LevelRank(l.Level) < eff.minRank {
 		return false, ReasonLevel
 	}
 
 	// Redaction BEFORE the cap check, so that a line dropped by the cap was
 	// never held in memory in its raw form any longer than one that is kept.
-	g.scrub(l)
+	g.scrub(l, eff)
 
 	l.Message = strings.TrimSpace(l.Message)
 	if l.Message == "" && len(l.Fields) == 0 {
@@ -142,24 +269,25 @@ func (g *Governor) Admit(l *ext.AppLog) (bool, Reason) {
 		l.Truncated = true
 	}
 
-	if l.SpanID != "" && g.maxLines > 0 && !g.allow(l.SpanID) {
+	if l.SpanID != "" && eff.maxLines > 0 && !g.allow(l.SpanID, eff.maxLines) {
 		return false, ReasonSpanCap
 	}
 	return true, ""
 }
 
-// scrub applies redaction to the message and every field value.
-func (g *Governor) scrub(l *ext.AppLog) {
-	for _, re := range g.patterns {
+// scrub applies redaction to the message and every field value, using the
+// resolved policy so a rule's extra patterns are honoured.
+func (g *Governor) scrub(l *ext.AppLog, eff effective) {
+	for _, re := range eff.patterns {
 		l.Message = re.ReplaceAllString(l.Message, "[REDACTED]")
 	}
 	for k, v := range l.Fields {
-		if g.redactField[strings.ToLower(k)] {
+		if eff.fields[strings.ToLower(k)] {
 			l.Fields[k] = "[REDACTED]"
 			continue
 		}
 		// A token in a field is exactly as leaked as one in the message.
-		for _, re := range g.patterns {
+		for _, re := range eff.patterns {
 			v = re.ReplaceAllString(v, "[REDACTED]")
 		}
 		l.Fields[k] = v
@@ -167,7 +295,8 @@ func (g *Governor) scrub(l *ext.AppLog) {
 }
 
 // allow reports whether this span may store another line, and counts it.
-func (g *Governor) allow(span string) bool {
+// maxLines is the resolved cap, which a per-rule block may have lowered.
+func (g *Governor) allow(span string, maxLines int) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
@@ -177,7 +306,7 @@ func (g *Governor) allow(span string) bool {
 			n = p
 		}
 	}
-	if n >= g.maxLines {
+	if n >= maxLines {
 		return false
 	}
 	if len(g.cur) >= g.maxSpans && !ok {

--- a/internal/applog/applog_test.go
+++ b/internal/applog/applog_test.go
@@ -166,3 +166,124 @@ func TestConcurrentAdmitIsSafe(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// The whole safety argument for trusting a producer-supplied route is that a
+// per-rule block can only TIGHTEN. If it could loosen, telemetry.app_logs
+// would be a suggestion rather than a guarantee, and a lying client could ask
+// for less protection than the floor.
+func TestPerRuleLogsOnlyTightens(t *testing.T) {
+	g := newGov(t, &config.AppLogsCfg{
+		Enabled:         true,
+		LevelMin:        "info",
+		MaxLinesPerSpan: 100,
+		Redact:          config.AppLogRedact{Patterns: []string{`GLOBAL-\d+`}},
+	})
+	if err := g.WithRules([]config.Rule{
+		{
+			Name:  "strict-payments",
+			Match: config.Match{Path: "/api/v1/payments/**"},
+			Logs: &config.RuleLogs{
+				LevelMin:        "error",
+				MaxLinesPerSpan: 2,
+				Redact:          config.AppLogRedact{Patterns: []string{`RULE-\d+`}, Fields: []string{"pan"}},
+			},
+		},
+		{
+			// Tries to loosen every setting. All of it must be ignored.
+			Name:  "loose-health",
+			Match: config.Match{Path: "/healthz"},
+			Logs: &config.RuleLogs{
+				LevelMin:        "debug", // lower than the global floor
+				MaxLinesPerSpan: 9000,    // higher than the global cap
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// --- the strict route ------------------------------------------------
+	if ok, r := g.Admit(&ext.AppLog{SpanID: "s1", Route: "/api/v1/payments/**",
+		Level: "warn", Message: "noise"}); ok || r != ReasonLevel {
+		t.Errorf("a rule raising the floor to error kept a warn: ok=%v r=%q", ok, r)
+	}
+	l := &ext.AppLog{SpanID: "s1", Route: "/api/v1/payments/**", Level: "error",
+		Message: "failed with RULE-123 and GLOBAL-456",
+		Fields:  map[string]string{"pan": "4111111111111111", "amount": "42"}}
+	if ok, r := g.Admit(l); !ok {
+		t.Fatalf("an error line on the strict route was dropped: %q", r)
+	}
+	if strings.Contains(l.Message, "RULE-123") {
+		t.Errorf("the rule's own pattern did not apply: %q", l.Message)
+	}
+	if strings.Contains(l.Message, "GLOBAL-456") {
+		t.Errorf("a rule block must ADD to the global patterns, not replace them: %q", l.Message)
+	}
+	if l.Fields["pan"] != "[REDACTED]" {
+		t.Errorf("the rule's field redaction did not apply: %v", l.Fields)
+	}
+	if l.Fields["amount"] != "42" {
+		t.Errorf("redaction ate an innocent field: %v", l.Fields)
+	}
+
+	// The rule's cap of 2 applies, not the global 100. One line is already in.
+	kept := 1
+	for i := 0; i < 5; i++ {
+		if ok, _ := g.Admit(&ext.AppLog{SpanID: "s1", Route: "/api/v1/payments/**",
+			Level: "error", Message: "more"}); ok {
+			kept++
+		}
+	}
+	if kept != 2 {
+		t.Errorf("the rule cap of 2 kept %d lines", kept)
+	}
+
+	// --- the route that tried to loosen ----------------------------------
+	if ok, r := g.Admit(&ext.AppLog{SpanID: "s2", Route: "/healthz",
+		Level: "debug", Message: "chatty"}); ok || r != ReasonLevel {
+		t.Errorf("a rule lowered the global floor: ok=%v r=%q", ok, r)
+	}
+	// And its inflated cap must not beat the global one.
+	allowed := 0
+	for i := 0; i < 150; i++ {
+		if ok, _ := g.Admit(&ext.AppLog{SpanID: "s3", Route: "/healthz",
+			Level: "info", Message: "tick"}); ok {
+			allowed++
+		}
+	}
+	if allowed != 100 {
+		t.Errorf("a rule raised the global cap: %d lines allowed, want 100", allowed)
+	}
+
+	// --- an unknown or absent route gets the global policy ---------------
+	// Safe precisely because rules only tighten: the worst a producer can do
+	// by lying is land on the floor.
+	unknown := &ext.AppLog{SpanID: "s4", Route: "/who/knows", Level: "info",
+		Message: "GLOBAL-999 and RULE-999"}
+	if ok, r := g.Admit(unknown); !ok {
+		t.Fatalf("an unknown route was dropped: %q", r)
+	}
+	if strings.Contains(unknown.Message, "GLOBAL-999") {
+		t.Error("the global pattern did not apply to an unknown route")
+	}
+	if !strings.Contains(unknown.Message, "RULE-999") {
+		t.Error("another rule's pattern leaked onto an unrelated route")
+	}
+}
+
+func TestRuleLogsDropDiscardsWithItsOwnReason(t *testing.T) {
+	g := newGov(t, &config.AppLogsCfg{Enabled: true})
+	if err := g.WithRules([]config.Rule{{
+		Name:  "no-logs-here",
+		Match: config.Match{Path: "/debug/**"},
+		Logs:  &config.RuleLogs{Drop: true},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if ok, r := g.Admit(&ext.AppLog{SpanID: "s", Route: "/debug/pprof", Level: "info", Message: "x"}); ok || r != ReasonRuleDrop {
+		t.Errorf("want drop/rule_drop, got ok=%v r=%q", ok, r)
+	}
+	// Everything else is unaffected.
+	if ok, _ := g.Admit(&ext.AppLog{SpanID: "s", Route: "/api/v1/orders", Level: "info", Message: "x"}); !ok {
+		t.Error("logs.drop on one route silenced another")
+	}
+}

--- a/internal/applog/collect.go
+++ b/internal/applog/collect.go
@@ -47,6 +47,9 @@ type Collector struct {
 	// counted rather than silent.
 	onDrop func(reason string)
 	onKeep func(n int)
+	// fanout receives every line that was stored, for the exporters. Separate
+	// from the sink so a slow exporter cannot stall persistence.
+	fanout func(lines []ext.AppLog)
 
 	mu     sync.Mutex
 	queue  []ext.AppLog
@@ -69,6 +72,11 @@ func NewCollector(gov *Governor, sink Sink, service string, logger *slog.Logger)
 // OnDrop and OnKeep install counters, normally the metrics collector's.
 func (c *Collector) OnDrop(f func(reason string)) { c.onDrop = f }
 func (c *Collector) OnKeep(f func(n int))         { c.onKeep = f }
+
+// OnStored installs a fan-out for lines that were persisted — the exporters.
+// Called after a successful save, so an exporter never sees a line the store
+// rejected.
+func (c *Collector) OnStored(f func(lines []ext.AppLog)) { c.fanout = f }
 
 // Start begins flushing. Sources are attached with Tail and Read.
 func (c *Collector) Start(ctx context.Context) {
@@ -117,6 +125,9 @@ func (c *Collector) flush(ctx context.Context) {
 	}
 	if c.onKeep != nil {
 		c.onKeep(len(batch))
+	}
+	if c.fanout != nil {
+		c.fanout(batch)
 	}
 }
 

--- a/internal/applog/collect.go
+++ b/internal/applog/collect.go
@@ -1,0 +1,392 @@
+// Package applog also collects lines the application already writes.
+//
+// The alternative — every service POSTing to /api/applogs/ingest — means
+// touching code in the services whose logs you most want, which are usually the
+// ones nobody wants to modify. A JSON logger writing to stdout needs no change
+// at all.
+package applog
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dwarka-prasad/optictrace/ext"
+	"github.com/dwarka-prasad/optictrace/internal/config"
+)
+
+// maxLineBytes bounds one line. A log without newlines — a minified blob, a
+// binary file named .log by mistake — must cost a bounded amount of memory
+// rather than however much the writer produced.
+const maxLineBytes = 1 << 20
+
+// Sink receives governed lines. The store implements it; tests use a fake.
+type Sink interface {
+	SaveAppLogs(ctx context.Context, lines []ext.AppLog) error
+}
+
+// Collector reads sources, governs each line, and batches to a Sink.
+type Collector struct {
+	gov      *Governor
+	sink     Sink
+	logger   *slog.Logger
+	service  string
+	batch    int
+	interval time.Duration
+
+	// onDrop is called with the reason for every discarded line, so drops stay
+	// counted rather than silent.
+	onDrop func(reason string)
+	onKeep func(n int)
+
+	mu     sync.Mutex
+	queue  []ext.AppLog
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// NewCollector builds a collector. service names lines whose source does not
+// override it.
+func NewCollector(gov *Governor, sink Sink, service string, logger *slog.Logger) *Collector {
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
+	}
+	return &Collector{
+		gov: gov, sink: sink, logger: logger, service: service,
+		batch: 200, interval: 500 * time.Millisecond,
+	}
+}
+
+// OnDrop and OnKeep install counters, normally the metrics collector's.
+func (c *Collector) OnDrop(f func(reason string)) { c.onDrop = f }
+func (c *Collector) OnKeep(f func(n int))         { c.onKeep = f }
+
+// Start begins flushing. Sources are attached with Tail and Read.
+func (c *Collector) Start(ctx context.Context) {
+	ctx, c.cancel = context.WithCancel(ctx)
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		t := time.NewTicker(c.interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-t.C:
+				c.flush(ctx)
+			case <-ctx.Done():
+				// Drain: the last lines before a shutdown are usually the ones
+				// explaining the shutdown.
+				c.flush(context.WithoutCancel(ctx))
+				return
+			}
+		}
+	}()
+}
+
+// Close stops collection and drains what is queued.
+func (c *Collector) Close() {
+	if c.cancel != nil {
+		c.cancel()
+	}
+	c.wg.Wait()
+}
+
+func (c *Collector) flush(ctx context.Context) {
+	c.mu.Lock()
+	batch := c.queue
+	c.queue = nil
+	c.mu.Unlock()
+	if len(batch) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := c.sink.SaveAppLogs(ctx, batch); err != nil {
+		// Never fatal: the application keeps running whatever the store does.
+		c.logger.Warn("app log collection: save failed", "error", err, "lines", len(batch))
+		return
+	}
+	if c.onKeep != nil {
+		c.onKeep(len(batch))
+	}
+}
+
+// submit governs one line and queues it if it survives.
+func (c *Collector) submit(l ext.AppLog) {
+	ok, reason := c.gov.Admit(&l)
+	if !ok {
+		if c.onDrop != nil {
+			c.onDrop(string(reason))
+		}
+		return
+	}
+	// Bounded: a logging storm costs a bounded amount of memory and then drops
+	// visibly rather than growing until the process dies. The counter is called
+	// outside the lock, so a slow callback cannot stall the reader.
+	c.mu.Lock()
+	full := len(c.queue) >= 10*c.batch
+	if !full {
+		c.queue = append(c.queue, l)
+	}
+	c.mu.Unlock()
+
+	if full && c.onDrop != nil {
+		c.onDrop("queue_full")
+	}
+}
+
+// Read consumes lines from r until EOF or ctx is done. Used for a child
+// process's stdout and stderr.
+func (c *Collector) Read(ctx context.Context, r io.Reader, src config.AppLogSource, echo io.Writer) {
+	parser, err := newParser(src, c.service)
+	if err != nil {
+		c.logger.Error("app log source is unusable", "error", err)
+		return
+	}
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64<<10), maxLineBytes)
+	for sc.Scan() {
+		line := sc.Text()
+		// Pass the line through untouched. Collecting a service's logs must not
+		// stop them reaching the place its operators already read.
+		if echo != nil {
+			fmt.Fprintln(echo, line)
+		}
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		c.submit(parser.parse(line))
+		if ctx.Err() != nil {
+			return
+		}
+	}
+	if err := sc.Err(); err != nil && !errors.Is(err, io.EOF) && ctx.Err() == nil {
+		c.logger.Warn("app log source read failed", "error", err)
+	}
+}
+
+// Tail follows a file, including across rotation.
+//
+// Starts at the END of an existing file: replaying a large log on every restart
+// would flood the store with history nobody asked for, and the retention window
+// would then silently discard the recent lines that were actually wanted.
+func (c *Collector) Tail(ctx context.Context, src config.AppLogSource) {
+	parser, err := newParser(src, c.service)
+	if err != nil {
+		c.logger.Error("app log source is unusable", "path", src.Path, "error", err)
+		return
+	}
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+
+		var (
+			f      *os.File
+			reader *bufio.Reader
+			ino    uint64
+		)
+		defer func() {
+			if f != nil {
+				f.Close()
+			}
+		}()
+
+		open := func() {
+			if f != nil {
+				f.Close()
+				f = nil
+			}
+			nf, err := os.Open(src.Path)
+			if err != nil {
+				return
+			}
+			// Seek to the end only on first open; after a rotation the new file
+			// is read from the start, because those lines are new.
+			if ino == 0 {
+				nf.Seek(0, io.SeekEnd)
+			}
+			ino = inodeOf(nf)
+			f = nf
+			reader = bufio.NewReaderSize(nf, 64<<10)
+		}
+		open()
+
+		ticker := time.NewTicker(250 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			if f == nil {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					open()
+					continue
+				}
+			}
+			line, err := reader.ReadString('\n')
+			if err == nil {
+				line = strings.TrimRight(line, "\r\n")
+				if strings.TrimSpace(line) != "" {
+					c.submit(parser.parse(line))
+				}
+				continue
+			}
+			// Partial line or EOF: wait, then check whether the file was
+			// rotated out from under us.
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+			if st, serr := os.Stat(src.Path); serr != nil || inodeOfStat(st) != ino {
+				ino = 1 // not first open: read a rotated file from its start
+				open()
+			}
+		}
+	}()
+}
+
+// parser turns a raw line into an AppLog according to one source's config.
+type parser struct {
+	service      string
+	json         bool
+	traceField   string
+	spanField    string
+	levelField   string
+	messageField string
+	routeField   string
+	spanPattern  *regexp.Regexp
+}
+
+func newParser(src config.AppLogSource, defaultService string) (*parser, error) {
+	p := &parser{
+		service:      firstNonEmpty(src.Service, defaultService),
+		json:         src.Format != "text",
+		traceField:   firstNonEmpty(src.TraceField, "trace_id"),
+		spanField:    firstNonEmpty(src.SpanField, "span_id"),
+		levelField:   firstNonEmpty(src.LevelField, "level"),
+		messageField: src.MessageField,
+		routeField:   firstNonEmpty(src.RouteField, "route"),
+	}
+	if src.SpanPattern != "" {
+		re, err := regexp.Compile(src.SpanPattern)
+		if err != nil {
+			return nil, err
+		}
+		p.spanPattern = re
+	}
+	return p, nil
+}
+
+func (p *parser) parse(line string) ext.AppLog {
+	out := ext.AppLog{Time: time.Now(), Service: p.service, Level: "info",
+		Message: line, Source: "collector"}
+
+	if p.json {
+		var doc map[string]any
+		if err := json.Unmarshal([]byte(line), &doc); err == nil {
+			out.TraceID = strField(doc, p.traceField)
+			out.SpanID = strField(doc, p.spanField)
+			out.Route = strField(doc, p.routeField)
+			if lvl := strField(doc, p.levelField); lvl != "" {
+				out.Level = lvl
+			}
+			out.Message = p.message(doc, line)
+			out.Fields = fieldsOf(doc, p.traceField, p.spanField, p.levelField, p.routeField, p.messageField)
+			if ts := strField(doc, "time"); ts != "" {
+				if parsed, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+					out.Time = parsed
+				}
+			}
+		}
+		// A line that is not JSON is kept as a message rather than dropped: a
+		// panic trace interleaved into a JSON log is exactly the line worth
+		// having, and it is never valid JSON.
+	}
+
+	if out.SpanID == "" && p.spanPattern != nil {
+		if m := p.spanPattern.FindStringSubmatch(line); len(m) > 1 {
+			out.SpanID = m[1]
+		}
+	}
+	return out
+}
+
+// message resolves the text, trying the configured key then the conventional
+// ones. A logger that writes "msg" should not need to be told to.
+func (p *parser) message(doc map[string]any, raw string) string {
+	if p.messageField != "" {
+		if v := strField(doc, p.messageField); v != "" {
+			return v
+		}
+	}
+	for _, k := range []string{"message", "msg"} {
+		if v := strField(doc, k); v != "" {
+			return v
+		}
+	}
+	return raw
+}
+
+func strField(doc map[string]any, key string) string {
+	if key == "" {
+		return ""
+	}
+	if v, ok := doc[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// fieldsOf keeps everything the line carried that is not already a first-class
+// column, stringified. Dropping them would throw away the structure that makes
+// a structured log worth having.
+func fieldsOf(doc map[string]any, skip ...string) map[string]string {
+	skipped := map[string]bool{"message": true, "msg": true, "time": true}
+	for _, k := range skip {
+		if k != "" {
+			skipped[k] = true
+		}
+	}
+	out := map[string]string{}
+	for k, v := range doc {
+		if skipped[k] {
+			continue
+		}
+		switch val := v.(type) {
+		case string:
+			out[k] = val
+		case nil:
+			// omit
+		default:
+			raw, err := json.Marshal(val)
+			if err == nil {
+				out[k] = string(raw)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/applog/collect_test.go
+++ b/internal/applog/collect_test.go
@@ -1,0 +1,207 @@
+package applog
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dwarka-prasad/optictrace/ext"
+	"github.com/dwarka-prasad/optictrace/internal/config"
+)
+
+type fakeSink struct {
+	mu    sync.Mutex
+	lines []ext.AppLog
+}
+
+func (f *fakeSink) SaveAppLogs(_ context.Context, lines []ext.AppLog) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lines = append(f.lines, lines...)
+	return nil
+}
+
+func (f *fakeSink) all() []ext.AppLog {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]ext.AppLog{}, f.lines...)
+}
+
+func newCollector(t *testing.T, cfg *config.AppLogsCfg) (*Collector, *fakeSink, map[string]int) {
+	t.Helper()
+	g := newGov(t, cfg)
+	sink := &fakeSink{}
+	c := NewCollector(g, sink, "svc", nil)
+	c.interval = 20 * time.Millisecond
+
+	drops := map[string]int{}
+	var mu sync.Mutex
+	c.OnDrop(func(reason string) {
+		mu.Lock()
+		drops[reason]++
+		mu.Unlock()
+	})
+	c.Start(context.Background())
+	t.Cleanup(c.Close)
+	return c, sink, drops
+}
+
+func TestCollectorParsesStructuredLines(t *testing.T) {
+	c, sink, _ := newCollector(t, &config.AppLogsCfg{
+		Enabled: true, LevelMin: "debug",
+		Redact: config.AppLogRedact{Patterns: []string{`Bearer\s+\S+`}},
+	})
+
+	var echoed bytes.Buffer
+	in := strings.NewReader(strings.Join([]string{
+		`{"time":"2026-08-19T10:00:00Z","level":"error","message":"charge failed","span_id":"abc123abc123abc1","trace_id":"t1","route":"/pay/**","order":"ord-1","attempt":2}`,
+		`{"level":"info","msg":"uses msg not message","span_id":"abc123abc123abc1"}`,
+		`not json at all, but a panic trace is never json`,
+		`{"level":"warn","message":"leaking Bearer topsecret123","span_id":"abc123abc123abc1"}`,
+		``,
+	}, "\n"))
+
+	c.Read(context.Background(), in, config.AppLogSource{Type: "stdout"}, &echoed)
+	c.Close()
+
+	got := sink.all()
+	// Three, not four: the non-JSON line has no span, so it is an orphan and
+	// the default policy drops it. Worth stating explicitly, because it is the
+	// tailer's sharpest edge — a panic trace interleaved into a JSON log is
+	// exactly the line you want and exactly the one with no span. The answer is
+	// drop_orphans: false or a span_pattern, not guessing an owner from the
+	// preceding line: under concurrency that attributes one request's stack
+	// trace to another's span.
+	if len(got) != 3 {
+		t.Fatalf("collected %d line(s), want 3: %+v", len(got), got)
+	}
+
+	first := got[0]
+	if first.Level != "error" || first.Message != "charge failed" {
+		t.Errorf("level/message: %q %q", first.Level, first.Message)
+	}
+	if first.SpanID != "abc123abc123abc1" || first.TraceID != "t1" || first.Route != "/pay/**" {
+		t.Errorf("correlation fields lost: %+v", first)
+	}
+	if first.Time.UTC().Format(time.RFC3339) != "2026-08-19T10:00:00Z" {
+		t.Errorf("the line's own timestamp was ignored: %s", first.Time)
+	}
+	// Structure is the point of a structured log; keeping only the message
+	// would throw away what makes it worth collecting.
+	if first.Fields["order"] != "ord-1" || first.Fields["attempt"] != "2" {
+		t.Errorf("extra fields lost: %v", first.Fields)
+	}
+	if _, dup := first.Fields["span_id"]; dup {
+		t.Errorf("span_id duplicated into fields: %v", first.Fields)
+	}
+
+	if got[1].Message != "uses msg not message" {
+		t.Errorf("a logger writing msg should not need configuring: %q", got[1].Message)
+	}
+	if strings.Contains(got[2].Message, "topsecret123") {
+		t.Errorf("collected lines must be redacted like ingested ones: %q", got[2].Message)
+	}
+
+	// Collecting must not stop the logs reaching wherever operators already
+	// read them — including the line that was NOT stored.
+	if !strings.Contains(echoed.String(), "charge failed") ||
+		!strings.Contains(echoed.String(), "panic trace") {
+		t.Errorf("lines were swallowed instead of echoed:\n%s", echoed.String())
+	}
+	// And the echo is the ORIGINAL text, not the redacted one — this process
+	// does not get to rewrite another program's output stream.
+	if !strings.Contains(echoed.String(), "Bearer topsecret123") {
+		t.Error("the echoed stream was altered; it must pass through untouched")
+	}
+}
+
+func TestCollectorExtractsSpanFromAPattern(t *testing.T) {
+	c, sink, _ := newCollector(t, &config.AppLogsCfg{Enabled: true, LevelMin: "debug"})
+	in := strings.NewReader("2026-08-19 INFO [span=abc123abc123abc1] charge captured\n")
+	c.Read(context.Background(), in, config.AppLogSource{
+		Type: "stdout", Format: "text", SpanPattern: `span=([0-9a-f]{16})`,
+	}, nil)
+	c.Close()
+
+	got := sink.all()
+	if len(got) != 1 {
+		t.Fatalf("collected %d line(s), want 1", len(got))
+	}
+	if got[0].SpanID != "abc123abc123abc1" {
+		t.Errorf("span not extracted from the text line: %q", got[0].SpanID)
+	}
+}
+
+// Orphans are the normal case for a text log, and they must be COUNTED rather
+// than vanishing — otherwise "my logs aren't appearing" has no explanation.
+func TestCollectorCountsDroppedOrphans(t *testing.T) {
+	c, sink, drops := newCollector(t, &config.AppLogsCfg{Enabled: true, LevelMin: "debug"})
+	c.Read(context.Background(), strings.NewReader("a line with no span at all\n"),
+		config.AppLogSource{Type: "stdout", Format: "text"}, nil)
+	c.Close()
+
+	if n := len(sink.all()); n != 0 {
+		t.Errorf("stored %d orphan line(s); the default is to drop them", n)
+	}
+	if drops["orphan"] != 1 {
+		t.Errorf("orphan drops = %v, want orphan:1", drops)
+	}
+}
+
+func TestTailFollowsAppendsAndRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "app.log")
+	if err := os.WriteFile(path, []byte(`{"message":"history","span_id":"aaaaaaaaaaaaaaa1"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c, sink, _ := newCollector(t, &config.AppLogsCfg{Enabled: true, LevelMin: "debug"})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c.Tail(ctx, config.AppLogSource{Type: "file", Path: path})
+	time.Sleep(150 * time.Millisecond)
+
+	appendLine := func(p, text string) {
+		f, err := os.OpenFile(p, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+		f.WriteString(text + "\n")
+		f.Close()
+	}
+	appendLine(path, `{"message":"appended","span_id":"aaaaaaaaaaaaaaa1"}`)
+	time.Sleep(300 * time.Millisecond)
+
+	// Rotate the way logrotate does: move the file aside, create a new one.
+	if err := os.Rename(path, path+".1"); err != nil {
+		t.Fatal(err)
+	}
+	appendLine(path, `{"message":"after rotation","span_id":"aaaaaaaaaaaaaaa1"}`)
+	time.Sleep(600 * time.Millisecond)
+	cancel()
+	c.Close()
+
+	var seen []string
+	for _, l := range sink.all() {
+		seen = append(seen, l.Message)
+	}
+	joined := strings.Join(seen, "|")
+
+	// Starting at the end is deliberate: replaying a large log on every restart
+	// would flood the store with history nobody asked for, and retention would
+	// then discard the recent lines that were actually wanted.
+	if strings.Contains(joined, "history") {
+		t.Errorf("tail replayed pre-existing history: %q", joined)
+	}
+	if !strings.Contains(joined, "appended") {
+		t.Errorf("tail missed an appended line: %q", joined)
+	}
+	if !strings.Contains(joined, "after rotation") {
+		t.Errorf("tail did not follow the rotation: %q", joined)
+	}
+}

--- a/internal/applog/inode_other.go
+++ b/internal/applog/inode_other.go
@@ -1,0 +1,20 @@
+//go:build !unix
+
+package applog
+
+import (
+	"io/fs"
+	"os"
+)
+
+// inodeOf has no portable equivalent off unix, so rotation is detected by the
+// file shrinking — which is what a copy-truncate rotation looks like.
+func inodeOf(f *os.File) uint64 {
+	st, err := f.Stat()
+	if err != nil {
+		return 0
+	}
+	return inodeOfStat(st)
+}
+
+func inodeOfStat(st fs.FileInfo) uint64 { return uint64(st.Size()) }

--- a/internal/applog/inode_unix.go
+++ b/internal/applog/inode_unix.go
@@ -1,0 +1,29 @@
+//go:build unix
+
+package applog
+
+import (
+	"io/fs"
+	"os"
+	"syscall"
+)
+
+// inodeOf identifies an open file so rotation can be detected. A path that
+// suddenly points at a different inode is a rotated log, not a truncated one,
+// and the new file has to be read from its start.
+func inodeOf(f *os.File) uint64 {
+	st, err := f.Stat()
+	if err != nil {
+		return 0
+	}
+	return inodeOfStat(st)
+}
+
+func inodeOfStat(st fs.FileInfo) uint64 {
+	if sys, ok := st.Sys().(*syscall.Stat_t); ok {
+		return sys.Ino
+	}
+	// No inode available: fall back to size, which at least notices a
+	// truncation-style rotation.
+	return uint64(st.Size())
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -559,6 +559,28 @@ func (a *AppLogsCfg) validate() error {
 	return nil
 }
 
+// validate checks a per-rule logs block at load time. A redaction pattern that
+// does not compile must fail startup: the alternative is an agent that runs
+// happily while the rule meant to mask credentials never applies.
+func (l *RuleLogs) validate() error {
+	if l == nil {
+		return nil
+	}
+	if l.LevelMin != "" && LevelRankKnown(l.LevelMin) < 0 {
+		return fmt.Errorf("logs.level_min %q is not a level (debug, info, warn, error, fatal)", l.LevelMin)
+	}
+	if l.MaxLinesPerSpan < 0 {
+		return fmt.Errorf("logs.max_lines_per_span %d must be >= 0 "+
+			"(a per-rule block can only lower the global cap, never remove it)", l.MaxLinesPerSpan)
+	}
+	for i, pat := range l.Redact.Patterns {
+		if _, err := regexp.Compile(pat); err != nil {
+			return fmt.Errorf("logs.redact.patterns[%d] (%q): %w", i, pat, err)
+		}
+	}
+	return nil
+}
+
 // LevelRankKnown returns the severity rank of a level, or -1 if it is not one
 // of the recognised names. Used to reject a typo in level_min at load time —
 // "warining" would otherwise silently keep everything.
@@ -644,6 +666,41 @@ type Rule struct {
 	// summed per consumer for usage/cost attribution. Metering is
 	// independent of capture rules: a restricted route can still meter.
 	Meter map[string]string `yaml:"meter"`
+	// Logs narrows the application-log policy for requests this rule matches.
+	//
+	// telemetry.app_logs sets the floor for every route; this tightens it per
+	// route, which is the shape the risk actually has. A payments handler
+	// deserves a stricter level floor and extra redaction than a health check,
+	// and expressing that globally means applying the strictest setting
+	// everywhere — which in practice means people set it loosely.
+	//
+	// Only ever tightens. A rule cannot raise a cap or lower a level floor
+	// below the global one: a per-route override that could weaken the global
+	// policy would make the global setting a suggestion rather than a
+	// guarantee, and reviewing one file would no longer tell you what is
+	// enforced.
+	Logs *RuleLogs `yaml:"logs"`
+}
+
+// RuleLogs is the per-rule application-log policy. Every field is optional;
+// an omitted field inherits telemetry.app_logs.
+type RuleLogs struct {
+	// LevelMin raises the severity floor for this route. Ignored if it would
+	// LOWER the global floor.
+	LevelMin string `yaml:"level_min"`
+	// MaxLinesPerSpan lowers the per-request line cap for this route. Ignored
+	// if it would raise the global cap. -1 is not accepted here: removing the
+	// cap is a global decision.
+	MaxLinesPerSpan int `yaml:"max_lines_per_span"`
+	// Redact adds patterns and field names on top of the global set. Additive
+	// only — there is no way to remove a global redaction, because a rule that
+	// could unmask something would make the global list unreviewable.
+	Redact AppLogRedact `yaml:"redact"`
+	// Drop discards application log lines for this route entirely. The
+	// honest way to say "never store what this handler logs" — a debug
+	// endpoint, or a route whose logs are known to carry secrets nothing can
+	// pattern-match reliably.
+	Drop bool `yaml:"drop"`
 }
 
 // Match selects requests by path glob and (optionally) HTTP methods.
@@ -913,6 +970,12 @@ func (c *Config) Validate() error {
 	if err := c.Telemetry.AppLogs.validate(); err != nil {
 		return err
 	}
+	for _, r := range c.Rules {
+		if r.Logs != nil && (c.Telemetry.AppLogs == nil || !c.Telemetry.AppLogs.Enabled) {
+			return fmt.Errorf("rule %q has a `logs:` block but telemetry.app_logs.enabled is not true — "+
+				"the block would be silently ignored", r.Name)
+		}
+	}
 	for _, o := range c.Telemetry.CORSOrigins {
 		if o == "*" {
 			// A wildcard means any page the operator visits can read the
@@ -1169,6 +1232,9 @@ func (r *Rule) validate() error {
 	}
 	if r.Sample != nil && (*r.Sample <= 0 || *r.Sample > 1) {
 		return fmt.Errorf("sample %v must be in (0, 1]", *r.Sample)
+	}
+	if err := r.Logs.validate(); err != nil {
+		return err
 	}
 	for name, path := range r.Meter {
 		if !strings.HasPrefix(path, "$.") || len(path) <= 2 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -519,6 +519,39 @@ type AppLogsCfg struct {
 	// applied to the message and to every structured field value; each match
 	// is replaced with [REDACTED].
 	Redact AppLogRedact `yaml:"redact"`
+	// Sources collect lines the application already writes, instead of
+	// requiring it to POST them. An app that logs JSON to stdout needs no code
+	// change at all — which matters, because the services whose logs you most
+	// want are usually the ones nobody wants to modify.
+	Sources []AppLogSource `yaml:"sources"`
+}
+
+// AppLogSource is one place to read application log lines from.
+type AppLogSource struct {
+	// Type is "stdout" (the child process started with `optictrace run -exec`)
+	// or "file".
+	Type string `yaml:"type"`
+	// Path is the file to tail, for type: file. Rotation is followed.
+	Path string `yaml:"path"`
+	// Service overrides the service name attributed to these lines. Defaults
+	// to service.name.
+	Service string `yaml:"service"`
+	// Format is "json" (the default) or "text". A text line has no fields and
+	// no span of its own unless SpanPattern finds one, so text sources mostly
+	// produce orphans — which is worth knowing before choosing the format
+	// rather than after seeing an empty dashboard.
+	Format string `yaml:"format"`
+	// Field names to read a JSON line's parts from. Empty values fall back to
+	// the conventional names, so a structured logger usually needs no mapping.
+	TraceField   string `yaml:"trace_field"`   // default: trace_id
+	SpanField    string `yaml:"span_field"`    // default: span_id
+	LevelField   string `yaml:"level_field"`   // default: level
+	MessageField string `yaml:"message_field"` // default: message, then msg
+	RouteField   string `yaml:"route_field"`   // default: route
+	// SpanPattern extracts a span id from a line that has no structured field
+	// for it — a regex with one capture group. The escape hatch for text logs
+	// and for loggers that only interpolate the id into the message.
+	SpanPattern string `yaml:"span_pattern"`
 }
 
 // AppLogRedact is the log-line equivalent of a rule's redact block.
@@ -540,6 +573,11 @@ func (a *AppLogsCfg) validate() error {
 	for i, pat := range a.Redact.Patterns {
 		if _, err := regexp.Compile(pat); err != nil {
 			return fmt.Errorf("telemetry.app_logs.redact.patterns[%d] (%q): %w", i, pat, err)
+		}
+	}
+	for i := range a.Sources {
+		if err := a.Sources[i].validate(i); err != nil {
+			return err
 		}
 	}
 	if a.LevelMin != "" && LevelRankKnown(a.LevelMin) < 0 {
@@ -600,6 +638,38 @@ func LevelRankKnown(level string) int {
 		return 5
 	}
 	return -1
+}
+
+// validate checks one source at load time.
+func (s *AppLogSource) validate(i int) error {
+	switch s.Type {
+	case "stdout":
+		if s.Path != "" {
+			return fmt.Errorf("telemetry.app_logs.sources[%d]: type stdout takes no path", i)
+		}
+	case "file":
+		if s.Path == "" {
+			return fmt.Errorf("telemetry.app_logs.sources[%d]: type file requires a path", i)
+		}
+	default:
+		return fmt.Errorf("telemetry.app_logs.sources[%d]: type %q is not stdout or file", i, s.Type)
+	}
+	switch s.Format {
+	case "", "json", "text":
+	default:
+		return fmt.Errorf("telemetry.app_logs.sources[%d]: format %q is not json or text", i, s.Format)
+	}
+	if s.SpanPattern != "" {
+		re, err := regexp.Compile(s.SpanPattern)
+		if err != nil {
+			return fmt.Errorf("telemetry.app_logs.sources[%d].span_pattern: %w", i, err)
+		}
+		if re.NumSubexp() != 1 {
+			return fmt.Errorf("telemetry.app_logs.sources[%d].span_pattern needs exactly one "+
+				"capture group (it is what identifies the span), got %d", i, re.NumSubexp())
+		}
+	}
+	return nil
 }
 
 // DropOrphanLines reports whether uncorrelated lines are discarded.

--- a/internal/export/applog_test.go
+++ b/internal/export/applog_test.go
@@ -1,0 +1,189 @@
+package export
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dwarka-prasad/optictrace/ext"
+	"github.com/dwarka-prasad/optictrace/internal/config"
+)
+
+// recordsOnly implements Exporter but NOT AppLogExporter — the third-party
+// exporter that must keep working untouched.
+type recordsOnly struct {
+	mu   sync.Mutex
+	seen int
+}
+
+func (r *recordsOnly) Name() string { return "records-only" }
+func (r *recordsOnly) Type() string { return "test" }
+func (r *recordsOnly) Export(_ context.Context, batch []*ext.Record) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.seen += len(batch)
+	return nil
+}
+func (r *recordsOnly) Close() error { return nil }
+
+// bothStreams accepts records and log lines.
+type bothStreams struct {
+	mu      sync.Mutex
+	records int
+	logs    []string
+}
+
+func (b *bothStreams) Name() string { return "both" }
+func (b *bothStreams) Type() string { return "test" }
+func (b *bothStreams) Export(_ context.Context, batch []*ext.Record) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.records += len(batch)
+	return nil
+}
+func (b *bothStreams) ExportAppLogs(_ context.Context, batch []*ext.AppLog) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, l := range batch {
+		b.logs = append(b.logs, l.Message)
+	}
+	return nil
+}
+func (b *bothStreams) Close() error { return nil }
+
+func (b *bothStreams) lines() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]string{}, b.logs...)
+}
+
+// dispatcherWith builds a Dispatcher around pre-made exporters, mirroring what
+// New does. Kept local so the test does not need config plumbing for a fake.
+func dispatcherWith(t *testing.T, exps ...Exporter) *Dispatcher {
+	t.Helper()
+	d := &Dispatcher{logger: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))}
+	for _, e := range exps {
+		w := &worker{exp: e, queue: make(chan *ext.Record, 64), batchSize: 16, flushEach: 20 * time.Millisecond}
+		if ale, ok := e.(ext.AppLogExporter); ok {
+			w.logExp = ale
+			w.logs = make(chan *ext.AppLog, 64)
+		}
+		d.workers = append(d.workers, w)
+		d.wg.Add(1)
+		go d.run(w)
+	}
+	return d
+}
+
+// The whole point of a separate optional interface: an exporter that predates
+// app logs keeps compiling and keeps receiving records.
+func TestRecordsOnlyExporterIsUnaffected(t *testing.T) {
+	ro := &recordsOnly{}
+	both := &bothStreams{}
+	d := dispatcherWith(t, ro, both)
+
+	if !d.AcceptsAppLogs() {
+		t.Error("AcceptsAppLogs should be true when any exporter takes lines")
+	}
+	d.Enqueue(&ext.Record{Path: "/a"})
+	d.EnqueueAppLog(&ext.AppLog{Message: "only the app-log exporter sees this"})
+	d.Shutdown()
+
+	ro.mu.Lock()
+	seen := ro.seen
+	ro.mu.Unlock()
+	if seen != 1 {
+		t.Errorf("records-only exporter received %d record(s), want 1", seen)
+	}
+	if got := both.lines(); len(got) != 1 || got[0] != "only the app-log exporter sees this" {
+		t.Errorf("app-log exporter received %v", got)
+	}
+}
+
+func TestNoAppLogExportersMeansNoWork(t *testing.T) {
+	d := dispatcherWith(t, &recordsOnly{})
+	if d.AcceptsAppLogs() {
+		t.Error("AcceptsAppLogs must be false when nothing takes lines")
+	}
+	// Must not panic or block on an exporter with no log queue.
+	d.EnqueueAppLog(&ext.AppLog{Message: "dropped on the floor, by design"})
+	d.Shutdown()
+}
+
+// Shutdown closes both queues and select picks a ready arm at random, so the
+// record arm can win while lines are still queued. Relying on close ORDER
+// loses the last batch about half the time; this asserts the drain.
+func TestShutdownDrainsQueuedLogLines(t *testing.T) {
+	for attempt := 0; attempt < 25; attempt++ {
+		both := &bothStreams{}
+		// flushEach long enough that only the shutdown drain can deliver these.
+		d := &Dispatcher{logger: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))}
+		w := &worker{exp: both, queue: make(chan *ext.Record, 64), batchSize: 100, flushEach: time.Hour,
+			logExp: both, logs: make(chan *ext.AppLog, 64)}
+		d.workers = append(d.workers, w)
+		d.wg.Add(1)
+		go d.run(w)
+
+		for i := 0; i < 5; i++ {
+			d.EnqueueAppLog(&ext.AppLog{Message: "queued"})
+		}
+		d.Enqueue(&ext.Record{Path: "/a"})
+		d.Shutdown()
+
+		if got := len(both.lines()); got != 5 {
+			t.Fatalf("attempt %d: shutdown delivered %d of 5 queued lines", attempt, got)
+		}
+	}
+}
+
+func TestFileExporterWritesBothStreamsToOneFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	e, err := newFileExporter(&config.ExporterCfg{Name: "audit", Type: "file", Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Export(context.Background(), []*ext.Record{{Path: "/api/v1/pay", Status: 201}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.ExportAppLogs(context.Background(), []*ext.AppLog{
+		{SpanID: "s1", Level: "error", Message: "gateway declined"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	e.Close()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("wrote %d line(s), want 2:\n%s", len(lines), raw)
+	}
+
+	// A consumer must be able to tell what a line IS without guessing from
+	// which fields happen to be present — a record and a log line share most.
+	var first map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &first); err != nil {
+		t.Fatal(err)
+	}
+	if _, tagged := first["kind"]; tagged {
+		t.Error("records must stay untagged, so existing consumers keep parsing them")
+	}
+	var second map[string]any
+	if err := json.Unmarshal([]byte(lines[1]), &second); err != nil {
+		t.Fatal(err)
+	}
+	if second["kind"] != "app_log" {
+		t.Errorf("log line not discriminated: %v", second)
+	}
+	if second["app_log"] == nil {
+		t.Errorf("log line payload missing: %v", second)
+	}
+}

--- a/internal/export/command.go
+++ b/internal/export/command.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dwarka-prasad/optictrace/ext"
 	"github.com/dwarka-prasad/optictrace/internal/config"
 	"github.com/dwarka-prasad/optictrace/internal/store"
 )
@@ -115,6 +116,27 @@ func (e *commandExporter) Export(_ context.Context, batch []*store.Record) error
 			// Broken pipe: mark dead so the next batch respawns.
 			e.cmd.Process.Kill() //nolint:errcheck
 			return fmt.Errorf("write to plugin: %w", err)
+		}
+	}
+	return nil
+}
+
+// ExportAppLogs streams governed log lines to the same executable's stdin,
+// tagged so the plugin can tell them apart from records.
+func (e *commandExporter) ExportAppLogs(_ context.Context, batch []*ext.AppLog) error {
+	if err := e.ensureRunning(); err != nil {
+		return err
+	}
+	for _, l := range batch {
+		line, err := json.Marshal(struct {
+			Kind string      `json:"kind"`
+			Log  *ext.AppLog `json:"app_log"`
+		}{Kind: "app_log", Log: l})
+		if err != nil {
+			return fmt.Errorf("marshal app log: %w", err)
+		}
+		if _, err := e.stdin.Write(append(line, '\n')); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -61,6 +61,13 @@ type worker struct {
 	delivered atomic.Int64
 	failed    atomic.Int64
 	dropped   atomic.Int64
+
+	// logs is non-nil only when the exporter implements ext.AppLogExporter.
+	// A separate queue rather than a shared one so a burst of log lines cannot
+	// delay records, which are the lower-volume and higher-value stream.
+	logs    chan *ext.AppLog
+	logExp  ext.AppLogExporter
+	logDrop atomic.Int64
 }
 
 // Dispatcher owns one worker per configured exporter.
@@ -111,6 +118,17 @@ func New(cfgs []config.ExporterCfg, logger *slog.Logger, m Metrics, serviceName 
 			batchSize: c.BatchSize,
 			flushEach: c.FlushEvery(),
 		}
+		// App-log support is optional and discovered, not configured: an
+		// exporter either accepts lines or it does not, and asking the operator
+		// to declare it would just be a second place to get it wrong.
+		if ale, ok := exp.(ext.AppLogExporter); ok {
+			w.logExp = ale
+			w.logs = make(chan *ext.AppLog, c.QueueSize)
+		} else {
+			logger.Info("exporter takes records only — application log lines will not "+
+				"reach it (its type does not implement app-log export)",
+				"exporter", c.Name, "type", c.Type)
+		}
 		d.workers = append(d.workers, w)
 		d.wg.Add(1)
 		go d.run(w)
@@ -119,6 +137,37 @@ func New(cfgs []config.ExporterCfg, logger *slog.Logger, m Metrics, serviceName 
 }
 
 // Enqueue hands a record to every exporter without ever blocking.
+// EnqueueAppLog fans one governed log line out to every exporter that accepts
+// them. Exporters without app-log support simply do not receive it.
+func (d *Dispatcher) EnqueueAppLog(l *ext.AppLog) {
+	for _, w := range d.workers {
+		if w.logs == nil {
+			continue
+		}
+		select {
+		case w.logs <- l:
+		default:
+			// Same posture as records: drop rather than block, and count it.
+			// Backpressure here would reach the request path eventually.
+			w.logDrop.Add(1)
+			if d.metrics != nil {
+				d.metrics.ExportDropped(w.exp.Name())
+			}
+		}
+	}
+}
+
+// AcceptsAppLogs reports whether any configured exporter takes log lines, so
+// the caller can skip the work entirely when none do.
+func (d *Dispatcher) AcceptsAppLogs() bool {
+	for _, w := range d.workers {
+		if w.logs != nil {
+			return true
+		}
+	}
+	return false
+}
+
 func (d *Dispatcher) Enqueue(rec *store.Record) {
 	for _, w := range d.workers {
 		select {
@@ -176,11 +225,56 @@ func (d *Dispatcher) run(w *worker) {
 		batch = batch[:0]
 	}
 
+	logs := make([]*ext.AppLog, 0, w.batchSize)
+	flushLogs := func() {
+		if len(logs) == 0 {
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		err := w.logExp.ExportAppLogs(ctx, logs)
+		cancel()
+		if err != nil {
+			w.failed.Add(int64(len(logs)))
+			if d.metrics != nil {
+				d.metrics.ExportFailed(w.exp.Name(), len(logs))
+			}
+			d.logger.Warn("app log export failed",
+				"exporter", w.exp.Name(), "lines", len(logs), "error", err)
+		} else {
+			w.delivered.Add(int64(len(logs)))
+			if d.metrics != nil {
+				d.metrics.ExportDelivered(w.exp.Name(), len(logs))
+			}
+		}
+		logs = logs[:0]
+	}
+
+	// A nil channel blocks forever in a select, so an exporter without app-log
+	// support simply never wakes on that arm — no extra branching needed.
+	logQueue := w.logs
+
 	for {
 		select {
 		case rec, ok := <-w.queue:
 			if !ok {
 				flush()
+				// Drain the log queue before closing the exporter. Shutdown
+				// closes both channels, and select picks a ready arm at random,
+				// so this arm can win while lines are still queued — relying on
+				// close ORDER here would lose the last batch about half the time.
+				//
+				// The nil check is load-bearing: the log arm sets logQueue to
+				// nil once it has drained, and ranging over a nil channel blocks
+				// forever rather than returning.
+				if logQueue != nil {
+					for l := range logQueue {
+						logs = append(logs, l)
+						if len(logs) >= w.batchSize {
+							flushLogs()
+						}
+					}
+				}
+				flushLogs()
 				if err := w.exp.Close(); err != nil {
 					d.logger.Warn("exporter close failed", "exporter", w.exp.Name(), "error", err)
 				}
@@ -190,8 +284,21 @@ func (d *Dispatcher) run(w *worker) {
 			if len(batch) >= w.batchSize {
 				flush()
 			}
+		case l, ok := <-logQueue:
+			if !ok {
+				// Records still arrive on their own queue; only stop selecting
+				// on this one.
+				logQueue = nil
+				flushLogs()
+				continue
+			}
+			logs = append(logs, l)
+			if len(logs) >= w.batchSize {
+				flushLogs()
+			}
 		case <-ticker.C:
 			flush()
+			flushLogs()
 		}
 	}
 }
@@ -199,6 +306,9 @@ func (d *Dispatcher) run(w *worker) {
 // Shutdown flushes pending batches and closes every exporter.
 func (d *Dispatcher) Shutdown() {
 	for _, w := range d.workers {
+		if w.logs != nil {
+			close(w.logs)
+		}
 		close(w.queue)
 	}
 	done := make(chan struct{})

--- a/internal/export/file.go
+++ b/internal/export/file.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/dwarka-prasad/optictrace/ext"
 	"github.com/dwarka-prasad/optictrace/internal/config"
 	"github.com/dwarka-prasad/optictrace/internal/store"
 )
@@ -26,7 +27,15 @@ func newFileExporter(c *config.ExporterCfg) (*fileExporter, error) {
 	if err := os.MkdirAll(filepath.Dir(c.Path), 0o755); err != nil {
 		return nil, err
 	}
-	e := &fileExporter{name: c.Name, path: c.Path, maxBytes: int64(c.MaxSizeMB) << 20}
+	// config.Parse defaults MaxSizeMB, but a caller constructing ExporterCfg
+	// programmatically bypasses that — and maxBytes 0 means `written >= 0`,
+	// which rotates after every single batch and leaves one line per file.
+	// Defend here so the exporter is correct however it was built.
+	sizeMB := c.MaxSizeMB
+	if sizeMB <= 0 {
+		sizeMB = 100
+	}
+	e := &fileExporter{name: c.Name, path: c.Path, maxBytes: int64(sizeMB) << 20}
 	if err := e.open(); err != nil {
 		return nil, err
 	}
@@ -55,6 +64,36 @@ func (e *fileExporter) Export(_ context.Context, batch []*store.Record) error {
 		line, err := json.Marshal(rec)
 		if err != nil {
 			return fmt.Errorf("marshal record: %w", err)
+		}
+		n, err := e.f.Write(append(line, '\n'))
+		if err != nil {
+			return err
+		}
+		e.written += int64(n)
+	}
+	if e.written >= e.maxBytes {
+		return e.rotate()
+	}
+	return nil
+}
+
+// ExportAppLogs writes governed log lines to the same JSONL stream.
+//
+// One stream, with a discriminator, rather than a second file: a consumer
+// reading an audit trail wants the request and the lines it wrote in one place
+// and in order, and splitting them means reassembling by timestamp — which is
+// the correlation problem this whole feature exists to avoid.
+func (e *fileExporter) ExportAppLogs(_ context.Context, batch []*ext.AppLog) error {
+	for _, l := range batch {
+		// The wrapper marks what a line IS. Without it a consumer has to guess
+		// from which fields happen to be present, and an app log and a record
+		// share most of them.
+		line, err := json.Marshal(struct {
+			Kind string      `json:"kind"`
+			Log  *ext.AppLog `json:"app_log"`
+		}{Kind: "app_log", Log: l})
+		if err != nil {
+			return fmt.Errorf("marshal app log: %w", err)
 		}
 		n, err := e.f.Write(append(line, '\n'))
 		if err != nil {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -185,6 +185,13 @@ func (ic *Interceptor) Wrap(next http.Handler) http.Handler {
 		// rules can only be decided with them, and a rule that cannot be
 		// decided does not apply.
 		policy := ic.engine.Load().EvaluateAttrs(engine.AttrsOf(r))
+		// Re-publish with the resolved route now that the policy is known: a
+		// per-rule `logs:` block keys on it, and the handler's log lines need
+		// to carry it.
+		if policy.RoutePattern != "" {
+			tc.Route = policy.RoutePattern
+			r = r.WithContext(tracectx.NewContext(r.Context(), tc))
+		}
 
 		// Uniform sampling draw, made up front. Tail-based rules can rescue
 		// a request this draw discarded, but only once the outcome is known

--- a/internal/review/markdown.go
+++ b/internal/review/markdown.go
@@ -91,6 +91,11 @@ func (r *Report) Markdown() string {
 		b.WriteString("### Sensitive values already in stored telemetry\n\n")
 		fmt.Fprintf(&b, "%d critical · %d high · %d medium — pre-existing, not introduced by this PR. Samples are masked.\n\n",
 			crit, high, med)
+		if r.LogLinesReviewed > 0 {
+			fmt.Fprintf(&b, "<sub>Includes %d application log line(s). A log line is free text, "+
+				"so its fix is a pattern or field name under `app_logs.redact` rather than a JSON path.</sub>\n\n",
+				r.LogLinesReviewed)
+		}
 		b.WriteString("| | Where | Field | Seen | Fix |\n|---|---|---|--:|---|\n")
 		for _, f := range r.Leaks {
 			if len(b.String()) > 40000 {

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dwarka-prasad/optictrace/ext"
 	"github.com/dwarka-prasad/optictrace/internal/config"
 	"github.com/dwarka-prasad/optictrace/internal/engine"
 	"github.com/dwarka-prasad/optictrace/internal/scan"
@@ -82,18 +83,28 @@ func (c Coverage) FieldPct() float64 {
 
 // Report is a complete review.
 type Report struct {
-	Window        string               `json:"window"`
-	Coverage      Coverage             `json:"coverage"`
-	PolicyChanges []PolicyChange       `json:"policy_changes"`
-	Leaks         []scan.Finding       `json:"leaks"`
-	Suggestions   []suggest.Suggestion `json:"suggestions"`
-	SpecFindings  []spec.Finding       `json:"spec_findings"`
-	ComparedBase  bool                 `json:"compared_base"`
+	Window        string         `json:"window"`
+	Coverage      Coverage       `json:"coverage"`
+	PolicyChanges []PolicyChange `json:"policy_changes"`
+	Leaks         []scan.Finding `json:"leaks"`
+	// LogLinesReviewed says how many application log lines were read. Printed
+	// because "no leaks" over zero lines means something very different from
+	// no leaks over forty thousand.
+	LogLinesReviewed int                  `json:"log_lines_reviewed"`
+	Suggestions      []suggest.Suggestion `json:"suggestions"`
+	SpecFindings     []spec.Finding       `json:"spec_findings"`
+	ComparedBase     bool                 `json:"compared_base"`
 }
 
 // Options configures a review.
 type Options struct {
 	Records []store.Record
+	// AppLogs are application log lines from the same window, optional.
+	// Reviewed alongside the records because they are the riskier surface: a
+	// payload is structured and can be masked by JSON path, a log line is free
+	// text. A PR check that reads only payloads passes the change that starts
+	// logging a card number.
+	AppLogs []ext.AppLog
 	Head    *config.Config // policy as of this PR (required)
 	Base    *config.Config // policy on the base branch (optional)
 	Spec    *spec.Spec     // optional: also run the breaking-change check
@@ -120,7 +131,12 @@ func Run(o Options) *Report {
 	for i := range o.Records {
 		sc.Add(&o.Records[i])
 	}
-	rep.Leaks = sc.Report().Findings
+	for i := range o.AppLogs {
+		sc.AddAppLog(&o.AppLogs[i])
+	}
+	report := sc.Report()
+	rep.Leaks = report.Findings
+	rep.LogLinesReviewed = report.LinesScanned
 	rep.Suggestions = suggest.Records(o.Records, head).Actionable()
 	if o.Spec != nil {
 		rep.SpecFindings = spec.Check(o.Spec, o.Records)

--- a/internal/store/clickhouse.go
+++ b/internal/store/clickhouse.go
@@ -80,6 +80,7 @@ CREATE TABLE IF NOT EXISTS app_logs (
 	service   String,
 	trace_id  String,
 	span_id   String,
+	route     String,
 	level     String,
 	message   String,
 	fields    String,
@@ -127,6 +128,8 @@ func NewClickHouse(dsn string) (*ClickHouseStore, error) {
 		`ALTER TABLE logs ADD COLUMN IF NOT EXISTS trace_id String DEFAULT ''`,
 		`ALTER TABLE logs ADD COLUMN IF NOT EXISTS span_id String DEFAULT ''`,
 		`ALTER TABLE logs ADD COLUMN IF NOT EXISTS parent_span String DEFAULT ''`,
+		// app_logs shipped in v0.9.0 without route.
+		`ALTER TABLE app_logs ADD COLUMN IF NOT EXISTS route String DEFAULT ''`,
 	} {
 		if _, err := db.ExecContext(ctx, decl); err != nil {
 			db.Close()

--- a/internal/store/clickhouse_applog.go
+++ b/internal/store/clickhouse_applog.go
@@ -26,8 +26,8 @@ func (s *ClickHouseStore) SaveAppLogs(ctx context.Context, lines []ext.AppLog) e
 		return err
 	}
 	stmt, err := tx.PrepareContext(ctx, `
-		INSERT INTO app_logs (id, ts, service, trace_id, span_id, level, message, fields, source, truncated)
-		VALUES (?,?,?,?,?,?,?,?,?,?)`)
+		INSERT INTO app_logs (id, ts, service, trace_id, span_id, route, level, message, fields, source, truncated)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?)`)
 	if err != nil {
 		tx.Rollback()
 		return err
@@ -47,7 +47,7 @@ func (s *ClickHouseStore) SaveAppLogs(ctx context.Context, lines []ext.AppLog) e
 			fields = string(raw)
 		}
 		if _, err := stmt.ExecContext(ctx, s.nextID(l.Time), l.Time.UnixMilli(), l.Service,
-			l.TraceID, l.SpanID, l.Level, l.Message, fields, l.Source,
+			l.TraceID, l.SpanID, l.Route, l.Level, l.Message, fields, l.Source,
 			uint8(boolInt(l.Truncated))); err != nil {
 			tx.Rollback()
 			return err
@@ -121,7 +121,7 @@ func (s *ClickHouseStore) QueryAppLogs(ctx context.Context, f ext.AppLogFilter) 
 		limit = 200
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, ts, service, trace_id, span_id, level, message, fields, source, truncated
+		`SELECT id, ts, service, trace_id, span_id, route, level, message, fields, source, truncated
 		 FROM app_logs`+clause+` ORDER BY ts ASC, id ASC LIMIT ? OFFSET ?`,
 		append(args, limit, f.Offset)...)
 	if err != nil {
@@ -137,7 +137,7 @@ func (s *ClickHouseStore) QueryAppLogs(ctx context.Context, f ext.AppLogFilter) 
 			fields    string
 			truncated uint8
 		)
-		if err := rows.Scan(&l.ID, &ts, &l.Service, &l.TraceID, &l.SpanID,
+		if err := rows.Scan(&l.ID, &ts, &l.Service, &l.TraceID, &l.SpanID, &l.Route,
 			&l.Level, &l.Message, &fields, &l.Source, &truncated); err != nil {
 			return nil, 0, err
 		}

--- a/internal/store/migrate_applog_test.go
+++ b/internal/store/migrate_applog_test.go
@@ -1,0 +1,67 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dwarka-prasad/optictrace/ext"
+	_ "modernc.org/sqlite"
+)
+
+// An app_logs table created by v0.9.0 has no route column. Opening it must
+// migrate rather than fail — someone upgrading in place is the normal case.
+func TestAppLogsRouteMigration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "old.db")
+	old, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Exactly the v0.9.0 shape: no route column.
+	if _, err := old.Exec(`CREATE TABLE app_logs (
+		id INTEGER PRIMARY KEY AUTOINCREMENT, ts INTEGER NOT NULL,
+		service TEXT NOT NULL DEFAULT '', trace_id TEXT NOT NULL DEFAULT '',
+		span_id TEXT NOT NULL DEFAULT '', level TEXT NOT NULL DEFAULT '',
+		message TEXT NOT NULL DEFAULT '', fields TEXT NOT NULL DEFAULT '',
+		source TEXT NOT NULL DEFAULT '', truncated INTEGER NOT NULL DEFAULT 0)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := old.Exec(
+		`INSERT INTO app_logs (ts, service, span_id, level, message) VALUES (?,?,?,?,?)`,
+		time.Now().UnixMilli(), "api", "span-1", "info", "written by the old version"); err != nil {
+		t.Fatal(err)
+	}
+	old.Close()
+
+	s, err := NewSQLite(path)
+	if err != nil {
+		t.Fatalf("opening a v0.9.0 store failed instead of migrating: %v", err)
+	}
+	defer s.Close()
+
+	lines, _, err := s.QueryAppLogs(context.Background(), ext.AppLogFilter{SpanID: "span-1"})
+	if err != nil {
+		t.Fatalf("query after migration: %v", err)
+	}
+	if len(lines) != 1 {
+		t.Fatalf("the pre-existing line was lost: %d line(s)", len(lines))
+	}
+	if lines[0].Message != "written by the old version" {
+		t.Errorf("message changed: %q", lines[0].Message)
+	}
+	if lines[0].Route != "" {
+		t.Errorf("a migrated row should have an empty route, got %q", lines[0].Route)
+	}
+	// And new writes carry a route.
+	if err := s.SaveAppLogs(context.Background(), []ext.AppLog{
+		{Time: time.Now(), SpanID: "span-2", Route: "/api/v1/payments/**", Level: "info", Message: "new"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fresh, _, _ := s.QueryAppLogs(context.Background(), ext.AppLogFilter{SpanID: "span-2"})
+	if len(fresh) != 1 || fresh[0].Route != "/api/v1/payments/**" {
+		t.Errorf("route not stored after migration: %+v", fresh)
+	}
+}

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -78,6 +78,7 @@ CREATE TABLE IF NOT EXISTS app_logs (
 	service   TEXT NOT NULL DEFAULT '',
 	trace_id  TEXT NOT NULL DEFAULT '',
 	span_id   TEXT NOT NULL DEFAULT '',
+	route     TEXT NOT NULL DEFAULT '',
 	level     TEXT NOT NULL DEFAULT '',
 	message   TEXT NOT NULL DEFAULT '',
 	fields    JSONB NOT NULL DEFAULT '{}'::jsonb,
@@ -89,6 +90,9 @@ CREATE TABLE IF NOT EXISTS app_logs (
 CREATE INDEX IF NOT EXISTS idx_app_logs_span  ON app_logs(span_id, ts);
 CREATE INDEX IF NOT EXISTS idx_app_logs_trace ON app_logs(trace_id, ts);
 CREATE INDEX IF NOT EXISTS idx_app_logs_ts    ON app_logs(ts);
+-- app_logs shipped in v0.9.0 without route, so an existing store needs it
+-- added. Postgres has IF NOT EXISTS for this, so no error matching is needed.
+ALTER TABLE app_logs ADD COLUMN IF NOT EXISTS route TEXT NOT NULL DEFAULT '';
 `
 
 // NewPostgres opens (and migrates) a Postgres-backed store. dsn is a standard

--- a/internal/store/postgres_applog.go
+++ b/internal/store/postgres_applog.go
@@ -28,8 +28,8 @@ func (s *PostgresStore) SaveAppLogs(ctx context.Context, lines []ext.AppLog) err
 	// One multi-row INSERT rather than a prepared statement in a loop: the
 	// round trips dominate, not the parsing.
 	var b strings.Builder
-	b.WriteString(`INSERT INTO app_logs (ts, service, trace_id, span_id, level, message, fields, source, truncated) VALUES `)
-	args := make([]any, 0, len(lines)*9)
+	b.WriteString(`INSERT INTO app_logs (ts, service, trace_id, span_id, route, level, message, fields, source, truncated) VALUES `)
+	args := make([]any, 0, len(lines)*10)
 	for i := range lines {
 		l := &lines[i]
 		if l.Time.IsZero() {
@@ -46,11 +46,12 @@ func (s *PostgresStore) SaveAppLogs(ctx context.Context, lines []ext.AppLog) err
 		if i > 0 {
 			b.WriteByte(',')
 		}
-		n := i * 9
+		n := i * 10
 		b.WriteString("($" + strconv.Itoa(n+1) + ",$" + strconv.Itoa(n+2) + ",$" + strconv.Itoa(n+3) +
 			",$" + strconv.Itoa(n+4) + ",$" + strconv.Itoa(n+5) + ",$" + strconv.Itoa(n+6) +
-			",$" + strconv.Itoa(n+7) + "::jsonb,$" + strconv.Itoa(n+8) + ",$" + strconv.Itoa(n+9) + ")")
-		args = append(args, l.Time.UnixMilli(), l.Service, l.TraceID, l.SpanID,
+			",$" + strconv.Itoa(n+7) + ",$" + strconv.Itoa(n+8) + "::jsonb,$" + strconv.Itoa(n+9) +
+			",$" + strconv.Itoa(n+10) + ")")
+		args = append(args, l.Time.UnixMilli(), l.Service, l.TraceID, l.SpanID, l.Route,
 			l.Level, l.Message, fields, l.Source, l.Truncated)
 	}
 	_, err := s.db.ExecContext(ctx, b.String(), args...)
@@ -121,7 +122,7 @@ func (s *PostgresStore) QueryAppLogs(ctx context.Context, f ext.AppLogFilter) ([
 	if limit <= 0 {
 		limit = 200
 	}
-	q := `SELECT id, ts, service, trace_id, span_id, level, message, fields, source, truncated
+	q := `SELECT id, ts, service, trace_id, span_id, route, level, message, fields, source, truncated
 		FROM app_logs` + clause + ` ORDER BY ts ASC, id ASC LIMIT ` + arg(limit) + ` OFFSET ` + arg(f.Offset)
 
 	rows, err := s.db.QueryContext(ctx, q, args...)
@@ -137,7 +138,7 @@ func (s *PostgresStore) QueryAppLogs(ctx context.Context, f ext.AppLogFilter) ([
 			ts     int64
 			fields []byte
 		)
-		if err := rows.Scan(&l.ID, &ts, &l.Service, &l.TraceID, &l.SpanID,
+		if err := rows.Scan(&l.ID, &ts, &l.Service, &l.TraceID, &l.SpanID, &l.Route,
 			&l.Level, &l.Message, &fields, &l.Source, &l.Truncated); err != nil {
 			return nil, 0, err
 		}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -68,6 +68,7 @@ CREATE TABLE IF NOT EXISTS app_logs (
 	service   TEXT NOT NULL DEFAULT '',
 	trace_id  TEXT NOT NULL DEFAULT '',
 	span_id   TEXT NOT NULL DEFAULT '',
+	route     TEXT NOT NULL DEFAULT '',
 	level     TEXT NOT NULL DEFAULT '',
 	message   TEXT NOT NULL DEFAULT '',
 	fields    TEXT NOT NULL DEFAULT '',
@@ -109,6 +110,13 @@ func NewSQLite(dsn string) (*SQLiteStore, error) {
 			db.Close()
 			return nil, fmt.Errorf("migrate schema (%s): %w", m.col, err)
 		}
+	}
+	// app_logs shipped in v0.9.0 without a route column, so an existing store
+	// needs it added rather than only being in CREATE TABLE.
+	if _, err := db.Exec(`ALTER TABLE app_logs ADD COLUMN route TEXT NOT NULL DEFAULT ''`); err != nil &&
+		!strings.Contains(err.Error(), "duplicate column") {
+		db.Close()
+		return nil, fmt.Errorf("migrate app_logs schema (route): %w", err)
 	}
 	return &SQLiteStore{db: db}, nil
 }

--- a/internal/store/sqlite_applog.go
+++ b/internal/store/sqlite_applog.go
@@ -29,8 +29,8 @@ func (s *SQLiteStore) SaveAppLogs(ctx context.Context, lines []ext.AppLog) error
 	defer tx.Rollback()
 
 	stmt, err := tx.PrepareContext(ctx, `
-		INSERT INTO app_logs (ts, service, trace_id, span_id, level, message, fields, source, truncated)
-		VALUES (?,?,?,?,?,?,?,?,?)`)
+		INSERT INTO app_logs (ts, service, trace_id, span_id, route, level, message, fields, source, truncated)
+		VALUES (?,?,?,?,?,?,?,?,?,?)`)
 	if err != nil {
 		return err
 	}
@@ -50,7 +50,7 @@ func (s *SQLiteStore) SaveAppLogs(ctx context.Context, lines []ext.AppLog) error
 			l.Time = time.Now()
 		}
 		if _, err := stmt.ExecContext(ctx, l.Time.UnixMilli(), l.Service, l.TraceID,
-			l.SpanID, l.Level, l.Message, fields, l.Source, boolInt(l.Truncated)); err != nil {
+			l.SpanID, l.Route, l.Level, l.Message, fields, l.Source, boolInt(l.Truncated)); err != nil {
 			return err
 		}
 	}
@@ -126,7 +126,7 @@ func (s *SQLiteStore) QueryAppLogs(ctx context.Context, f ext.AppLogFilter) ([]e
 	if limit <= 0 {
 		limit = 200
 	}
-	q := `SELECT id, ts, service, trace_id, span_id, level, message, fields, source, truncated
+	q := `SELECT id, ts, service, trace_id, span_id, route, level, message, fields, source, truncated
 		FROM app_logs` + clause + ` ORDER BY ts ASC, id ASC LIMIT ? OFFSET ?`
 	rows, err := s.db.QueryContext(ctx, q, append(args, limit, f.Offset)...)
 	if err != nil {
@@ -168,7 +168,7 @@ func scanAppLog(sc scannable) (*ext.AppLog, error) {
 		fields    string
 		truncated int
 	)
-	if err := sc.Scan(&l.ID, &ts, &l.Service, &l.TraceID, &l.SpanID,
+	if err := sc.Scan(&l.ID, &ts, &l.Service, &l.TraceID, &l.SpanID, &l.Route,
 		&l.Level, &l.Message, &fields, &l.Source, &truncated); err != nil {
 		return nil, err
 	}

--- a/internal/tracectx/tracectx.go
+++ b/internal/tracectx/tracectx.go
@@ -35,6 +35,10 @@ type Context struct {
 	// Sampled carries the caller's sampling decision, so OpticTrace does not
 	// export spans for traces the application already decided to drop.
 	Sampled bool
+	// Route is the rule pattern this request matched, resolved by the engine.
+	// Carried here because it is what a per-rule `logs:` block keys on, and a
+	// log handler has the context but not the policy.
+	Route string
 	// Inherited reports whether a usable traceparent arrived. False means the
 	// ids here were generated, and this hop is the root of a new trace.
 	Inherited bool

--- a/sdks/express/engine.js
+++ b/sdks/express/engine.js
@@ -181,6 +181,25 @@ function redactBody(raw, contentType, policy) {
   return `<${contentType || 'unknown'} body, ${Buffer.byteLength(raw)} bytes captured>`;
 }
 
+/**
+ * Whether the BODY may be stored for this exchange.
+ *
+ * Mirrors engine.Policy.KeepBody. Two details matter for parity: the record is
+ * ALWAYS emitted — metrics and metadata are never sampled — and keep_errors
+ * means 5xx, not 4xx. A 404 is usually the client's problem, and rescuing it
+ * would defeat the sampling it is meant to work alongside.
+ */
+function keepBody(policy, drew, status, elapsedMs) {
+  if (drew) return true;
+  if (policy.keepErrors && status >= 500) return true;
+  return policy.keepSlowerThanMs !== null && elapsedMs >= policy.keepSlowerThanMs;
+}
+
+/** Whether any tail rule applies, so bytes must be buffered up front. */
+function tailSampled(policy) {
+  return policy.keepErrors || policy.keepSlowerThanMs !== null;
+}
+
 /** `meter: {name: "$.usage.total_tokens"}` -> {name: [["usage","total_tokens"]]}. */
 function parseMeters(spec, ruleName) {
   const out = {};
@@ -371,6 +390,8 @@ function labelValue(src, { headers = {}, query = {}, path = '', requestBody, res
 
 module.exports = {
   Engine,
+  keepBody,
+  tailSampled,
   sanitizeHeaders,
   sanitizeQuery,
   redactBody,

--- a/sdks/express/index.js
+++ b/sdks/express/index.js
@@ -13,6 +13,8 @@ const fs = require('fs');
 const yaml = require('js-yaml');
 const {
   Engine,
+  keepBody,
+  tailSampled,
   sanitizeHeaders,
   sanitizeQuery,
   redactBody,
@@ -56,13 +58,18 @@ function optictrace(options = {}) {
     const ctx = trace.fromHeader(req.headers[trace.HEADER]);
     const start = process.hrtime.bigint();
     const policy = engine.evaluate(req.method, req.path ?? req.url.split('?')[0]);
-    const sampled = policy.sampleRate >= 1 || Math.random() < policy.sampleRate;
+    // The up-front draw. Tail-based rules can rescue a request this draw
+    // discarded, but only once the outcome is known — so when they are
+    // configured the bytes are buffered regardless and the call is made at the
+    // end, in keepBody().
+    const drew = policy.sampleRate >= 1 || Math.random() < policy.sampleRate;
+    const buffer = drew || tailSampled(policy);
 
     // --- request body capture: tee the raw stream, never consume it ------
     let reqChunks = null;
     let reqBytes = 0;
     let reqTruncated = false;
-    if (sampled && policy.captureRequestBody) {
+    if (buffer && policy.captureRequestBody) {
       reqChunks = [];
       req.on('data', (chunk) => {
         reqBytes += chunk.length;
@@ -98,7 +105,7 @@ function optictrace(options = {}) {
     // metering is independent of capture, which is what lets a rule keep a
     // prompt private while still counting the tokens in it. Without this,
     // `restrict: [response_body]` silently zeroes the billing.
-    if ((sampled && policy.captureResponseBody) || Object.keys(policy.meters).length > 0) {
+    if ((buffer && policy.captureResponseBody) || Object.keys(policy.meters).length > 0) {
       respChunks = [];
     }
     const origWrite = res.write.bind(res);
@@ -137,7 +144,12 @@ function optictrace(options = {}) {
         record.request_headers = sanitizeHeaders(req.headers, policy);
         record.response_headers = sanitizeHeaders(res.getHeaders(), policy);
       }
-      if (reqChunks && reqChunks.length) {
+      // The record is ALWAYS shipped: a request that produced no record is
+      // invisible to every count and percentile. Sampling decides whether the
+      // BODY is stored.
+      const keep = keepBody(policy, drew, res.statusCode, durationMs);
+
+      if (reqChunks && reqChunks.length && keep) {
         record.request_body = redactBody(
           Buffer.concat(reqChunks).toString('utf8'),
           req.headers['content-type'],
@@ -152,7 +164,9 @@ function optictrace(options = {}) {
         // still counting the tokens in it.
         const meters = extractMeters(rawResponse, policy);
         if (Object.keys(meters).length) record.meters = meters;
-        if (policy.captureResponseBody) {
+        // Buffered for metering is not the same as allowed to be stored, and
+        // neither is buffered for a tail rule that did not fire.
+        if (policy.captureResponseBody && keep) {
           governedResponse = redactBody(
             rawResponse,
             String(res.getHeader('content-type') ?? ''),

--- a/sdks/express/test/smoke.test.js
+++ b/sdks/express/test/smoke.test.js
@@ -46,6 +46,31 @@ assert.deepStrictEqual(
   redactPath({ echo: { card: { number: '4111' } }, card: { number: '2222' } }, ['**', 'card', 'number']),
   { echo: { card: { number: REDACTED } }, card: { number: REDACTED } },
 );
+// --- tail-based sampling parity --------------------------------------------
+{
+  const { keepBody, tailSampled } = require('../engine');
+  const tailCfg = require('js-yaml').load(`
+version: 1
+service: { name: t }
+rules:
+  - name: hot
+    match: { path: "/hot/**" }
+    sample: 0.0001
+    keep_errors: true
+    keep_slower_than: 10ms
+`);
+  const hot = new Engine(tailCfg).evaluate('GET', '/hot/reads');
+  assert.ok(tailSampled(hot), 'tail rules must force buffering');
+  assert.ok(!keepBody(hot, false, 200, 1), 'an unsampled fast 200 must keep no body');
+  assert.ok(keepBody(hot, false, 500, 1), 'keep_errors must rescue a 5xx');
+  // keep_errors means 5xx. A 404 is usually the client's problem, and rescuing
+  // it would defeat the sampling it works alongside.
+  assert.ok(!keepBody(hot, false, 404, 1), 'keep_errors must NOT rescue a 4xx');
+  assert.ok(keepBody(hot, false, 200, 25), 'keep_slower_than must rescue a slow request');
+  assert.ok(keepBody(hot, true, 200, 1), 'a drawn request always keeps its body');
+  assert.strictEqual(hot.keepSlowerThanMs, 10, 'go-style duration not parsed');
+}
+
 const eng = new Engine(require('js-yaml').load(CONFIG));
 const p = eng.evaluate('POST', '/auth/login');
 assert.strictEqual(p.captureRequestBody, false);

--- a/sdks/fastapi/optictrace_fastapi/__init__.py
+++ b/sdks/fastapi/optictrace_fastapi/__init__.py
@@ -77,7 +77,12 @@ class OpticTraceMiddleware:
         method = scope["method"]
         path = scope["path"]
         policy = self.engine.evaluate(method, path)
-        sampled = policy.sample_rate >= 1.0 or random.random() < policy.sample_rate
+        # The up-front draw. Tail-based rules can rescue a request this draw
+        # discarded, but only once the outcome is known — so when they are
+        # configured the bytes are buffered regardless and the decision is made
+        # at the end, in Policy.keep_body().
+        drew = policy.sample_rate >= 1.0 or random.random() < policy.sample_rate
+        buffer_bytes = drew or policy.tail_sampled()
 
         req_headers = {
             k.decode("latin-1"): v.decode("latin-1") for k, v in scope.get("headers", [])
@@ -100,8 +105,8 @@ class OpticTraceMiddleware:
             "resp_trunc": False,
         }
 
-        capture_req = sampled and policy.capture_request_body
-        capture_resp = sampled and policy.capture_response_body
+        capture_req = buffer_bytes and policy.capture_request_body
+        capture_resp = buffer_bytes and policy.capture_response_body
         # Meters read the response bytes even when the body is not STORED:
         # metering is independent of capture, which is what lets a rule keep a
         # prompt private while still counting the tokens in it. Without this,
@@ -143,8 +148,12 @@ class OpticTraceMiddleware:
         finally:
             current_span.reset(token)
             duration_ms = (time.perf_counter() - start) * 1000
+            # The record is ALWAYS built: a request that produced none is
+            # invisible to every count and percentile. Sampling decides whether
+            # the BODY is stored.
+            keep_body = policy.keep_body(drew, state["status"], duration_ms)
             record = self._build_record(
-                scope, method, path, policy, req_headers, state, duration_ms, ctx
+                scope, method, path, policy, req_headers, state, duration_ms, ctx, keep_body
             )
             if self.console_log or not self.ingest_url:
                 print(json.dumps({"msg": "http_exchange", **record}), flush=True)
@@ -152,7 +161,8 @@ class OpticTraceMiddleware:
                 # Fire-and-forget in a worker thread — urllib is blocking.
                 asyncio.get_running_loop().run_in_executor(None, self._ship, record)
 
-    def _build_record(self, scope, method, path, policy, req_headers, state, duration_ms, ctx=None):
+    def _build_record(self, scope, method, path, policy, req_headers, state, duration_ms,
+                      ctx=None, keep_body=True):
         client = scope.get("client") or ("", 0)
         record = {
             # RFC3339. `%z` renders "+0530", which the agent's strict RFC3339
@@ -180,7 +190,7 @@ class OpticTraceMiddleware:
         if policy.capture_headers:
             record["request_headers"] = policy.sanitize_headers(req_headers)
             record["response_headers"] = policy.sanitize_headers(state["resp_headers"])
-        if state["req_body"]:
+        if state["req_body"] and keep_body:
             record["request_body"] = policy.redact_body(
                 bytes(state["req_body"]), req_headers.get("content-type", "")
             )
@@ -192,7 +202,9 @@ class OpticTraceMiddleware:
             if meters:
                 record["meters"] = meters
             # Buffered for metering is not the same as allowed to be stored.
-            if policy.capture_response_body:
+            # Buffered for metering is not the same as allowed to be stored,
+            # and neither is buffered for a tail rule that did not fire.
+            if policy.capture_response_body and keep_body:
                 governed_response = policy.redact_body(
                     bytes(state["resp_body"]), state["resp_headers"].get("content-type", "")
                 )

--- a/sdks/fastapi/optictrace_fastapi/engine.py
+++ b/sdks/fastapi/optictrace_fastapi/engine.py
@@ -62,6 +62,28 @@ def redact_path(node: Any, path: list[str]) -> Any:
     return node
 
 
+def _parse_duration(value) -> Optional[float]:
+    """Go-style durations ("250ms", "1s", "2m") in milliseconds.
+
+    optic.yaml is written for the Go agent, so the spellings it accepts are the
+    ones this has to understand — a config that works there and is silently
+    ignored here is the kind of divergence nobody goes looking for.
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    try:
+        if text.endswith("ms"):
+            return float(text[:-2])
+        if text.endswith("s"):
+            return float(text[:-1]) * 1000
+        if text.endswith("m"):
+            return float(text[:-1]) * 60_000
+        return float(text)
+    except ValueError as exc:
+        raise ValueError(f"optic.yaml: cannot parse duration {value!r}") from exc
+
+
 def _parse_meters(spec: dict, rule_name: str) -> dict:
     """`meter: {name: "$.usage.total_tokens"}` -> {name: [["usage","total_tokens"]]}.
 
@@ -173,7 +195,30 @@ class Policy:
     matched_rules: list[str] = field(default_factory=list)
     route_pattern: str = ""
     sample_rate: float = 1.0
+    # Tail-based keeps. `sample` is a draw made up front; these rescue a
+    # request AFTER the outcome is known, because a coin flip that discards
+    # your 500s is worse than no sampling at all.
+    keep_errors: bool = False
+    keep_slower_than_ms: Optional[float] = None
     meters: dict = field(default_factory=dict)  # name -> [path segments]
+
+    def keep_body(self, drew: bool, status: int, elapsed_ms: float) -> bool:
+        """Whether the BODY may be stored for this exchange.
+
+        Mirrors engine.Policy.KeepBody. Two details matter for parity: the
+        record is ALWAYS emitted — metrics and metadata are never sampled — and
+        keep_errors means 5xx, not 4xx. A 404 is usually the client's problem,
+        and rescuing it would defeat the sampling it works alongside.
+        """
+        if drew:
+            return True
+        if self.keep_errors and status >= 500:
+            return True
+        return self.keep_slower_than_ms is not None and elapsed_ms >= self.keep_slower_than_ms
+
+    def tail_sampled(self) -> bool:
+        """Whether any tail rule applies, so bytes must be buffered up front."""
+        return self.keep_errors or self.keep_slower_than_ms is not None
 
     def extract_meters(self, raw: bytes) -> dict:
         """Pull numeric usage out of a response body.
@@ -229,6 +274,8 @@ class _Rule:
     redact_paths: list[list[str]]
     labels: dict[str, str]
     sample: Optional[float]
+    keep_errors: bool
+    keep_slower_than_ms: Optional[float]
     meters: dict[str, list[list[str]]]
 
 
@@ -268,6 +315,8 @@ class Engine:
                     redact_paths=paths,
                     labels=r.get("labels") or {},
                     sample=r.get("sample"),
+                    keep_errors=r.get("keep_errors") is True,
+                    keep_slower_than_ms=_parse_duration(r.get("keep_slower_than")),
                     meters=_parse_meters(r.get("meter") or {}, r.get("name") or f"#{i}"),
                 )
             )
@@ -289,6 +338,14 @@ class Engine:
             policy.route_pattern = r.raw_pattern
             if r.sample is not None:
                 policy.sample_rate = r.sample
+            if r.keep_errors:
+                policy.keep_errors = True
+            if r.keep_slower_than_ms is not None:
+                policy.keep_slower_than_ms = (
+                    r.keep_slower_than_ms
+                    if policy.keep_slower_than_ms is None
+                    else min(policy.keep_slower_than_ms, r.keep_slower_than_ms)
+                )
             if "request_body" in r.restrict:
                 policy.capture_request_body = False
             if "response_body" in r.restrict:

--- a/sdks/fastapi/test_middleware.py
+++ b/sdks/fastapi/test_middleware.py
@@ -26,6 +26,15 @@ rules:
     meter:
       tokens: "$.usage.total_tokens"
 
+  - name: sample-hot-reads
+    match: { path: "/hot/**" }
+    sample: 0.0001
+    keep_errors: true
+    # Deliberately far above any in-process call. At 10ms the interpreter's own
+    # warm-up rescues requests for being slow, which would make the
+    # keep_errors assertions below pass or fail for the wrong reason.
+    keep_slower_than: 30s
+
   - name: no-capture-on-auth
     match: { path: "/auth/**" }
     restrict: [request_body, response_body, headers]
@@ -63,9 +72,13 @@ async def echo_app(scope, receive, send):
     if scope["path"].startswith("/ai/"):
         out["usage"] = {"prompt_tokens": 86, "completion_tokens": 42, "total_tokens": 128}
     payload = json.dumps(out).encode()
+    status = 201
+    for k, v in scope.get("headers", []):
+        if k == b"x-status":
+            status = int(v)
     await send({
         "type": "http.response.start",
-        "status": 201,
+        "status": status,
         "headers": [(b"content-type", b"application/json")],
     })
     await send({"type": "http.response.body", "body": payload})
@@ -191,6 +204,39 @@ async def main():
     ai = emitted[-1]
     assert ai.get("meters", {}).get("tokens") == 128, f"meters not extracted: {ai.get('meters')}"
     assert "response_body" not in ai, "restricted response body was stored"
+
+    # --- tail-based sampling ------------------------------------------------
+    # sample is a coin flip made up front; keep_errors and keep_slower_than
+    # rescue the requests worth having after the outcome is known. A coin flip
+    # that discards your 500s is worse than no sampling at all.
+    await call(mw, "GET", "/hot/ok", {"content-type": "application/json"}, b"{}")
+    sampled_out = emitted[-1]
+    assert "request_body" not in sampled_out, "sample: 0.0001 stored a body anyway"
+    assert sampled_out["status"] == 201, "the record itself must still be emitted"
+
+    # A 500 is rescued...
+    await call(mw, "GET", "/hot/boom", {"content-type": "application/json", "x-status": "500"}, b"{}")
+    rescued = emitted[-1]
+    assert rescued["status"] == 500
+    assert "response_body" in rescued, "keep_errors did not rescue a 5xx body"
+
+    # ...a 404 is not. keep_errors means 5xx: a 404 is usually the client's
+    # problem, and rescuing it would defeat the sampling it works alongside.
+    await call(mw, "GET", "/hot/missing", {"content-type": "application/json", "x-status": "404"}, b"{}")
+    not_rescued = emitted[-1]
+    assert not_rescued["status"] == 404
+    assert "response_body" not in not_rescued, "keep_errors rescued a 4xx, which is not an error here"
+
+    # keep_slower_than is asserted at the policy level rather than by timing a
+    # real call, so the check does not depend on how fast this machine is.
+    hot_policy = mw.engine.evaluate("GET", "/hot/reads")
+    assert hot_policy.tail_sampled(), "tail rules must force buffering"
+    assert not hot_policy.keep_body(False, 200, 1), "an unsampled fast 200 must keep no body"
+    assert hot_policy.keep_body(False, 500, 1), "keep_errors must rescue a 5xx"
+    assert not hot_policy.keep_body(False, 404, 1), "keep_errors must NOT rescue a 4xx"
+    assert hot_policy.keep_body(False, 200, 31_000), "keep_slower_than must rescue a slow request"
+    assert hot_policy.keep_body(True, 200, 1), "a drawn request always keeps its body"
+    assert hot_policy.keep_slower_than_ms == 30_000, "go-style duration not parsed"
 
     print("✓ ASGI middleware integration checks passed")
     if os.environ.get("OPTIC_AGENT_URL"):

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -87,5 +87,16 @@ nothing ever asked one. Run it that way in CI.
 that already has one gets the filter loaded by a different classloader than the
 one serving requests.
 
-For `javax.servlet` (Spring Boot 2, Tomcat 9), change the import and dependency
-— the rest of the code is unchanged.
+### Spring Boot 2 / Tomcat 9 (`javax.servlet`)
+
+```bash
+./scripts/gen-javax.sh          # -> target/javax-src
+```
+
+The two servlet APIs differ only in package name for everything this SDK
+touches, so the javax variant is **generated** rather than kept as a second
+copy. Two copies of the same engine drift, and the copy nobody runs is the one
+that drifts. The script fails if a `jakarta.` reference survives the rewrite —
+that would mean a new API surface it does not know about — and CI compiles *and
+runs* the generated variant against `javax.servlet-api:4.0.1`, so it is tested
+rather than assumed.

--- a/sdks/java/scripts/gen-javax.sh
+++ b/sdks/java/scripts/gen-javax.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Generate the javax.servlet variant of the SDK from the jakarta sources.
+#
+#   ./scripts/gen-javax.sh [outdir]     # default: target/javax-src
+#
+# The jakarta and javax servlet APIs differ only in package name for everything
+# this SDK touches, so the variant is GENERATED rather than maintained as a
+# second copy. Two copies of the same engine drift, and the copy nobody runs is
+# the one that drifts — this repo has already learned that from its SDKs.
+#
+# Spring Boot 2 and Tomcat 9 are javax; Spring Boot 3, Quarkus 3 and Tomcat 10+
+# are jakarta.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+OUT="${1:-target/javax-src}"
+SRC="src/main/java/io/github/dwarkaprasad/optictrace"
+TEST_SRC="src/test/java/io/github/dwarkaprasad/optictrace"
+DEST="$OUT/io/github/dwarkaprasad/optictrace"
+
+rm -rf "$OUT"
+mkdir -p "$DEST"
+
+# The test suite is rewritten too, so the variant can be RUN and not merely
+# compiled. A generated copy nobody executes is the copy that breaks.
+for f in "$SRC"/*.java "$TEST_SRC"/*.java; do
+  # Only the import lines and any qualified references change. Nothing else in
+  # this SDK is servlet-version specific — if that stops being true, this script
+  # should start failing rather than silently producing something that compiles
+  # and misbehaves, which is what the grep below is for.
+  sed 's/\bjakarta\.servlet\b/javax.servlet/g' "$f" > "$DEST/$(basename "$f")"
+done
+
+# A jakarta reference surviving the rewrite means a new API surface appeared
+# that this script does not know about.
+if grep -rn "jakarta\." "$DEST" >/dev/null 2>&1; then
+  echo "✗ jakarta references survived the rewrite:" >&2
+  grep -rn "jakarta\." "$DEST" >&2
+  exit 1
+fi
+
+count=$(find "$DEST" -name '*.java' | wc -l | tr -d ' ')
+echo "✓ generated $count javax source file(s) in $OUT"
+echo "  compile with javax.servlet:javax.servlet-api:4.0.1 on the classpath"

--- a/sdks/java/src/main/java/io/github/dwarkaprasad/optictrace/OpticTraceFilter.java
+++ b/sdks/java/src/main/java/io/github/dwarkaprasad/optictrace/OpticTraceFilter.java
@@ -76,7 +76,12 @@ public final class OpticTraceFilter implements Filter {
         String method = request.getMethod();
         String path = request.getRequestURI();
         Policy policy = engine.evaluate(method, path);
-        boolean sampled = policy.sampleRate >= 1.0 || ThreadLocalRandom.current().nextDouble() < policy.sampleRate;
+        // The up-front draw. Tail-based rules can rescue a request this draw
+        // discarded, but only once the outcome is known — so when they are
+        // configured the bytes are buffered regardless and the decision is
+        // made at the end.
+        boolean drew = policy.sampleRate >= 1.0 || ThreadLocalRandom.current().nextDouble() < policy.sampleRate;
+        boolean buffer = drew || policy.tailSampled();
 
         Map<String, String> requestHeaders = headersOf(request);
 
@@ -85,12 +90,12 @@ public final class OpticTraceFilter implements Filter {
         TraceContext ctx = TraceContext.fromHeader(request.getHeader(TraceContext.HEADER));
         TraceContext.set(ctx);
 
-        CapturingRequest wrappedReq = new CapturingRequest(request, sampled && policy.captureRequestBody, policy.captureLimit);
+        CapturingRequest wrappedReq = new CapturingRequest(request, buffer && policy.captureRequestBody, policy.captureLimit);
         // Response bytes are buffered when the body is stored OR when a meter
         // needs them: metering is independent of capture, so restricting the
         // body must not silently zero the billing.
         CapturingResponse wrappedRes = new CapturingResponse(response,
-                (sampled && policy.captureResponseBody) || policy.hasMeters(), policy.captureLimit);
+                (buffer && policy.captureResponseBody) || policy.hasMeters(), policy.captureLimit);
 
         long start = System.nanoTime();
         int status = 200;
@@ -102,27 +107,26 @@ public final class OpticTraceFilter implements Filter {
             double durationMs = (System.nanoTime() - start) / 1_000_000.0;
             TraceContext.clear();
 
-            // Tail-based keeps: rescue a request AFTER the outcome is known.
-            // A coin flip that discards your 500s is worse than no sampling.
-            boolean keep = sampled
-                    || (policy.keepErrors && status >= 400)
-                    || (policy.keepSlowerThanMs != null && durationMs >= policy.keepSlowerThanMs);
-
-            if (keep) {
-                Map<String, Object> record = buildRecord(
-                        request, wrappedReq, wrappedRes, policy, requestHeaders, method, path, status, durationMs, ctx);
-                if (consoleLog || shipper == null) {
-                    System.out.println(writeJson(record));
-                }
-                if (shipper != null) shipper.enqueue(record);
+            // The record is ALWAYS emitted: metrics and metadata are never
+            // sampled, and a request that produced no record at all is
+            // invisible to every count and percentile. Sampling decides
+            // whether the BODY is stored, and the tail-based rules rescue the
+            // bodies worth having after the outcome is known.
+            boolean keepBody = policy.keepBody(drew, status, durationMs);
+            Map<String, Object> record = buildRecord(request, wrappedReq, wrappedRes, policy,
+                    requestHeaders, method, path, status, durationMs, ctx, keepBody);
+            if (consoleLog || shipper == null) {
+                System.out.println(writeJson(record));
             }
+            if (shipper != null) shipper.enqueue(record);
         }
     }
 
     private Map<String, Object> buildRecord(HttpServletRequest request, CapturingRequest req,
                                             CapturingResponse res, Policy policy,
                                             Map<String, String> requestHeaders, String method, String path,
-                                            int status, double durationMs, TraceContext ctx) {
+                                            int status, double durationMs, TraceContext ctx,
+                                            boolean keepBody) {
         Map<String, Object> record = new LinkedHashMap<>();
         // RFC3339 with a 'Z'. The agent parses strictly; the FastAPI SDK once
         // sent "+0530" and had every record rejected with a 400.
@@ -152,7 +156,7 @@ public final class OpticTraceFilter implements Filter {
 
         byte[] reqBody = req.captured();
         String governedRequest = null;
-        if (reqBody.length > 0 && policy.captureRequestBody) {
+        if (reqBody.length > 0 && policy.captureRequestBody && keepBody) {
             governedRequest = policy.redactBody(reqBody, request.getContentType());
             record.put("request_body", governedRequest);
             if (req.truncated()) record.put("req_truncated", true);
@@ -163,8 +167,9 @@ public final class OpticTraceFilter implements Filter {
         if (respBody.length > 0) {
             Map<String, Double> meters = policy.extractMeters(respBody);
             if (!meters.isEmpty()) record.put("meters", meters);
-            // Buffered for metering is not the same as allowed to be stored.
-            if (policy.captureResponseBody) {
+            // Buffered for metering is not the same as allowed to be stored,
+            // and neither is buffered for a tail rule that did not fire.
+            if (policy.captureResponseBody && keepBody) {
                 governedResponse = policy.redactBody(respBody, res.getContentType());
                 record.put("response_body", governedResponse);
                 if (res.truncated()) record.put("resp_truncated", true);

--- a/sdks/java/src/main/java/io/github/dwarkaprasad/optictrace/Policy.java
+++ b/sdks/java/src/main/java/io/github/dwarkaprasad/optictrace/Policy.java
@@ -43,6 +43,26 @@ public final class Policy {
         this.captureLimit = limit;
     }
 
+    /**
+     * Whether the BODY may be stored for this exchange.
+     *
+     * <p>Mirrors engine.Policy.KeepBody. Two details matter for parity: the
+     * record is always emitted — metrics and metadata are never sampled — and
+     * keep_errors means 5xx, not 4xx. A 404 is usually the client's problem and
+     * counting it as an error to rescue would defeat the sampling it is meant
+     * to work with.
+     */
+    public boolean keepBody(boolean drew, int status, double elapsedMs) {
+        if (drew) return true;
+        if (keepErrors && status >= 500) return true;
+        return keepSlowerThanMs != null && elapsedMs >= keepSlowerThanMs;
+    }
+
+    /** Whether any tail-based rule applies, so bytes must be buffered up front. */
+    public boolean tailSampled() {
+        return keepErrors || keepSlowerThanMs != null;
+    }
+
     public boolean hasMeters() {
         return !meters.isEmpty();
     }

--- a/sdks/java/src/test/java/io/github/dwarkaprasad/optictrace/SelfTest.java
+++ b/sdks/java/src/test/java/io/github/dwarkaprasad/optictrace/SelfTest.java
@@ -78,6 +78,11 @@ public final class SelfTest {
                 restrict: [response_body]
                 meter:
                   tokens: "$.usage.total_tokens"
+              - name: sample-hot-reads
+                match: { path: "/hot/**" }
+                sample: 0.0001
+                keep_errors: true
+                keep_slower_than: 10ms
               - name: no-capture-on-auth
                 match: { path: "/auth/**" }
                 restrict: [request_body, response_body, headers]
@@ -142,6 +147,18 @@ public final class SelfTest {
         check("meters sum across arrays",
                 Double.valueOf(30.0).equals(e.evaluate("POST", "/ai/x")
                         .extractMeters("{\"usage\":[{\"total_tokens\":10},{\"total_tokens\":20}]}".getBytes()).get("tokens")));
+
+        // Tail-based sampling. sample is a draw made up front; keep_errors and
+        // keep_slower_than rescue what is worth having once the outcome is known.
+        Policy hot = e.evaluate("GET", "/hot/reads");
+        check("tail rules force buffering even at a tiny sample rate", hot.tailSampled());
+        check("an unsampled fast 200 keeps no body", !hot.keepBody(false, 200, 1));
+        check("keep_errors rescues a 5xx", hot.keepBody(false, 500, 1));
+        // keep_errors means 5xx. A 404 is usually the client's problem, and
+        // rescuing it would defeat the sampling it works alongside.
+        check("keep_errors does NOT rescue a 4xx", !hot.keepBody(false, 404, 1));
+        check("keep_slower_than rescues a slow request", hot.keepBody(false, 200, 25));
+        check("a drawn request always keeps its body", hot.keepBody(true, 200, 1));
 
         Policy auth = e.evaluate("POST", "/auth/login");
         check("restrict disables all capture", !auth.captureRequestBody && !auth.captureResponseBody && !auth.captureHeaders);


### PR DESCRIPTION
The feature gaps. Stacked on #31 — review that first, or read the last four commits here.

## 1. Collect logs the app already writes

Ingestion required every service to POST to `/api/applogs/ingest`, which means touching code in the services whose logs you most want — usually the ones nobody wants to modify.

```bash
optictrace run -config optic.yaml -exec "python app.py"
```
```yaml
telemetry:
  app_logs:
    sources:
      - { type: file, path: /var/log/app.jsonl }
```

Proved against a shell script that knows nothing about OpticTrace: 8 lines collected, fields preserved, secrets redacted.

Four decisions worth reviewing:

- **The child's output is echoed through untouched.** Collecting a service's logs must not stop them reaching wherever its operators already read them, and this process does not get to rewrite another program's output stream — the echo shows the raw line even when the stored one is redacted.
- **Tailing starts at the END of an existing file.** Replaying a large log on every restart floods the store with history nobody asked for, and retention would then discard the recent lines that were actually wanted. Rotation is followed by inode; a rotated-in file *is* read from its start.
- **A non-JSON line — a panic trace — has no span, so it is an orphan and dropped by default.** That is the tailer's sharpest edge, so a text source with no `span_pattern` now warns at startup rather than leaving someone with an empty dashboard. The fix is `span_pattern` or `drop_orphans: false`, never inferring the owner from the preceding line: under concurrency that files one request's stack trace against another's span.
- **`-exec` mirrors the child's exit status, but only after the shutdown drain.** The first version called `os.Exit` from the wait goroutine, which skipped the drain and lost the last lines of a crashing process — exactly the lines worth having.

## 2. Per-rule log policy

```yaml
rules:
  - name: payments
    match: { path: "/api/v1/payments/**" }
    logs:
      level_min: error
      max_lines_per_span: 2
      redact: { patterns: ['\b\d{13,19}\b'], fields: [pan] }
```

**It can only tighten.** A higher floor, a lower cap, additional redaction — never the reverse. That is what makes it safe to resolve the policy from a route the *producer* reports without verifying it: the worst a lying or silent client can do is land on the global floor. If a block could ever loosen, `telemetry.app_logs` would become a suggestion rather than a guarantee. There's a test for each direction, including a rule that tries to lower the floor and raise the cap and is ignored on both.

`logs:` with the feature disabled is now a config error rather than dead config.

`route` is persisted, with an in-place migration for the v0.9.0 schema in all three drivers — a field in the JSON that silently never persists reads as empty for reasons nothing explains.

## 3. `review` reads log lines

`scan` already did; `review` didn't, so the PR bot would pass a change that starts logging a card number. It now prints how many lines it read, because "no leaks" over zero lines means something very different from no leaks over forty thousand.

## 4. Tail-based sampling everywhere — and two bugs

FastAPI ignored `keep_errors`/`keep_slower_than` entirely, so a config that sampled a hot route threw away exactly the errors it was written to keep.

Two divergences found while fixing it:

- **Java applied `keep_errors` at status >= 400.** In the Go engine it means 5xx — a 404 is usually the client's problem, and rescuing it defeats the sampling it works alongside. Java also used the keep decision to drop the whole *record*, where Go always emits the record and gates only the body.
- **Express parsed both settings and never used them.** Dead config, which is worse than unsupported config because it looks like it works.

Each SDK now asserts the 5xx-not-4xx boundary directly.

## 5. `javax.servlet` variant of the Java SDK

Generated by `scripts/gen-javax.sh`, not maintained as a second copy — and the script fails if a `jakarta.` reference survives the rewrite, so a new API surface announces itself instead of compiling into something subtly wrong. CI compiles **and runs** the full 59 checks against it.

## Verification

- 45 conformance sub-tests, 0 failures, across sqlite / postgres / clickhouse (real Postgres 16 and ClickHouse 24.3)
- All four SDKs pass; the Java suite passes on **both** jakarta and javax (59 checks each)
- `make lint`, `make test-all`, `-race` on applog/scan/review/root, 15/15 rule tests
- The tailer and per-rule policy verified end to end against a running agent, including the drop counters

One test correction worth noting: my first FastAPI tail-sampling test used `keep_slower_than: 10ms`, which the interpreter's own warm-up exceeds — so the 404 was rescued for being *slow* and the `keep_errors` assertion passed for the wrong reason. Pinned to 30s with the timing checked at the policy level instead.

## Still open

- App logs are invisible to the **exporters** (`scan` and `review` now read them; the file/webhook/OTLP exporters do not)
- The v0.10.0 container image never finished publishing — `ghcr.io/...:latest` is still v0.9.0, because the Dockerfile emulates the Next.js build under arm64 instead of cross-compiling
- `HOMEBREW_TAP_TOKEN` unset, so `brew install` is two releases behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)
