### PR TITLE
feat: generate optic.yaml from an OpenAPI or Swagger document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Versions `0.4.0`–`0.6.0` were development milestones that were never tagged;
 `0.7.0` is the first public release and contains all of that work.
 
+## [Unreleased]
+
+### Added
+
+- **`optictrace init -spec openapi.yaml`** generates a starting `optic.yaml` from an OpenAPI 3.x or Swagger 2.0 document. Governance is otherwise written by hand against an API you may not have written, and the gaps surface only once traffic flows. A specification already lists the routes and payload shapes, so most of a first draft can be derived: credential headers from declared `securitySchemes` (the one thing a spec states rather than implies), metadata-only capture on `/login`-shaped routes, and `redact.json_fields` for payload fields whose names are unambiguous, each annotated with its confidence and reason.
+
+  The generated file leads with what it is **not**: a spec describes what an API claims, and a field the document does not model cannot be masked by a rule derived from it. Caveats print to stderr so a redirect still yields a clean file, `init` refuses to overwrite an existing config, and it validates its own output before handing it over — a scaffolding tool that emits config the agent then rejects teaches people the format is unreliable.
+
+  `$ref` is resolved (including through `allOf`/`anyOf`/`oneOf`), path templates become globs, arrays contribute their element fields without an index, self-referencing schemas terminate, and remote `$ref` URLs are deliberately not fetched.
+
+### Fixed
+
+- **`card.number` was not recognised as a card number.** The sensitive-name heuristics matched `card_number` but not the `card: { number: ... }` shape every payment API actually uses, so the single most important field to mask was missed — by `optictrace suggest` on live traffic as well as by the new scaffolder. Nested parent/leaf pairs are now matched for card and bank-account numbers, deliberately as a *pair* so that `order.number` and `page.number` stay unflagged: a heuristic that flags every number field gets muted, and a muted heuristic protects nothing.
+
 ## [0.11.0] — 2026-08-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Prometheus dimensions.
 - [Pull-request reviews](#pull-request-reviews)
 - [Traffic-powered tooling](#traffic-powered-tooling)
 - [Following one request](#following-one-request-across-services) — [what it logged](#what-the-request-logged)
+- [Start from your OpenAPI spec](#start-from-your-openapi-spec) — `optictrace init`
 - [Examples](#examples) — runnable apps, not snippets
 - [Export plugins](#export-plugins)
 - [Framework SDKs](#framework-sdks)
@@ -1429,6 +1430,45 @@ proxy, not asserted from the code:
 - **The linter catches real breakage.** A proposed spec dropping a field was rejected with *"clients send request field `credit_card` (28 times, last 22m ago)"* and a non-zero exit.
 - **Plugins receive governed data only.** A Python CSV plugin and a file exporter both ran live; neither output contained a card number or a restricted payload.
 - **A clean clone works.** Cloned fresh from GitHub: builds, six test packages pass, CLI runs.
+
+---
+
+## Start from your OpenAPI spec
+
+Writing governance by hand against an API you may not have written means finding
+out what you missed once traffic flows. A specification already lists the routes
+and payload shapes, so most of the first draft can be derived:
+
+```bash
+optictrace init -spec openapi.yaml -out optic.yaml
+```
+
+Reads OpenAPI 3.x and Swagger 2.0, YAML or JSON, and produces rules for what the
+document actually states — credential headers from its `securitySchemes`,
+metadata-only capture on `/login`-shaped routes, and `redact.json_fields` for
+payload fields whose names are unambiguous, each annotated with why:
+
+```yaml
+  - name: redact-api-v1-payments-charge
+    match:
+      path: "/api/v1/payments/charge"
+    redact:
+      query_params: ["api_key"]
+      json_fields:
+        - "$.**.card.number"    # high · payment card data is PCI-DSS scope
+        - "$.**.card.cvv"       # high · payment card data is PCI-DSS scope
+        - "$.**.customer.email" # medium · email addresses are personal data
+```
+
+**It is a starting point and says so in its own header.** A spec describes what
+an API *claims*; governance has to hold for what it *does*. A field the document
+does not model cannot be masked by a rule derived from it, specs drift, and a
+field called `ref` can hold a card number — which is what `optictrace scan`
+finds on real traffic and no name heuristic ever will. Caveats print to stderr,
+so `init -spec x.yaml > optic.yaml` still gives you a clean file.
+
+It refuses to overwrite an existing `optic.yaml`, and validates what it produced
+before handing it over.
 
 ---
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -58,6 +58,7 @@ import (
 	"github.com/dwarka-prasad/optictrace/internal/replay"
 	"github.com/dwarka-prasad/optictrace/internal/review"
 	"github.com/dwarka-prasad/optictrace/internal/ruletest"
+	"github.com/dwarka-prasad/optictrace/internal/scaffold"
 	"github.com/dwarka-prasad/optictrace/internal/scan"
 	"github.com/dwarka-prasad/optictrace/internal/spec"
 	"github.com/dwarka-prasad/optictrace/internal/store"
@@ -83,6 +84,10 @@ func Run(args []string, ver string) {
 	configPath := fs.String("config", "optic.yaml", "path to optic.yaml")
 	uiDir := fs.String("ui", "ui/out", "static dashboard directory (optional)")
 	execCmd := fs.String("exec", "", "run: start this command and collect its stdout/stderr as application logs")
+	initService := fs.String("service", "", "init: service name (default: the spec's title)")
+	initListen := fs.String("proxy-listen", "", "init: sidecar listen address, e.g. :8080")
+	initUpstream := fs.String("upstream", "", "init: upstream URL to forward to")
+	initLow := fs.Bool("include-low", false, "init: also mask low-confidence names (name, first_name)")
 	specPath := fs.String("spec", "", "OpenAPI spec file (check/mock/sdk)")
 	outPath := fs.String("out", "", "output file (spec/sdk); default stdout")
 	window := fs.Duration("window", 24*time.Hour, "traffic window to analyze (spec/check)")
@@ -136,11 +141,13 @@ func Run(args []string, ver string) {
 			from: *fromAgent, fromFile: *fromFile, token: *token,
 			window: *window, out: *outPath, failOn: *reviewFailOn,
 		})
+	case "init":
+		initConfig(*specPath, *outPath, *initService, *initListen, *initUpstream, *initLow)
 	case "version":
 		fmt.Println("optictrace", version)
 	default:
 		fmt.Fprintf(os.Stderr,
-			"unknown command %q\n  (run, validate, test, scan, suggest, review, purge, replay,\n   spec, check, sdk, mock, version)\n", cmd)
+			"unknown command %q\n  (init, run, validate, test, scan, suggest, review, purge,\n   replay, spec, check, sdk, mock, version)\n", cmd)
 		os.Exit(2)
 	}
 }
@@ -619,6 +626,73 @@ func startChild(command string, collector *applog.Collector, sources []config.Ap
 		done <- code
 	}()
 	return done
+}
+
+// initConfig scaffolds an optic.yaml from an OpenAPI or Swagger document.
+//
+// The bootstrap problem: governance is otherwise written by hand against an API
+// you may not have written, and the gaps only surface once traffic flows. A
+// specification already lists the routes and payload shapes, so most of a first
+// draft can be derived rather than guessed.
+func initConfig(specPath, outPath, service, listen, upstream string, includeLow bool) {
+	if specPath == "" {
+		fmt.Fprintln(os.Stderr, "✗ -spec is required: point it at an OpenAPI or Swagger document\n"+
+			"  optictrace init -spec openapi.yaml -out optic.yaml")
+		os.Exit(2)
+	}
+	raw, err := os.ReadFile(specPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "✗ %v\n", err)
+		os.Exit(1)
+	}
+	doc, err := scaffold.Parse(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "✗ %s: %v\n", specPath, err)
+		os.Exit(1)
+	}
+	res := scaffold.Generate(doc, scaffold.Options{
+		ServiceName: service, Listen: listen, Upstream: upstream, IncludeLow: includeLow,
+	})
+
+	// Validate what was generated before handing it over. A scaffolding tool
+	// that emits a file the agent then refuses is worse than no tool: it
+	// teaches people the config format is unreliable.
+	cfg, err := config.Parse([]byte(res.YAML))
+	if err == nil {
+		err = cfg.Validate()
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "✗ generated config did not validate — this is a bug in `init`, "+
+			"please report it with the spec that caused it:\n  %v\n", err)
+		os.Exit(1)
+	}
+
+	if outPath == "" {
+		fmt.Print(res.YAML)
+	} else {
+		// Never clobber: an existing optic.yaml is a reviewed policy, and
+		// overwriting it from a spec would silently discard hand-written rules.
+		if _, err := os.Stat(outPath); err == nil {
+			fmt.Fprintf(os.Stderr, "✗ %s already exists — refusing to overwrite a reviewed policy.\n"+
+				"  Write elsewhere with -out, or delete it deliberately.\n", outPath)
+			os.Exit(1)
+		}
+		if err := os.WriteFile(outPath, []byte(res.YAML), 0o600); err != nil {
+			fmt.Fprintf(os.Stderr, "✗ %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("✓ wrote %s — %d route(s), %d rule(s), %d field(s) masked\n",
+			outPath, res.Routes, res.Rules, res.MaskedFields)
+	}
+
+	// To stderr, so `optictrace init -spec x.yaml > optic.yaml` still produces a
+	// clean file while the caveats stay visible.
+	if len(res.Notes) > 0 {
+		fmt.Fprintln(os.Stderr, "\nBefore trusting this:")
+		for _, n := range res.Notes {
+			fmt.Fprintf(os.Stderr, "  · %s\n", n)
+		}
+	}
 }
 
 func loadTraffic(configPath string, window time.Duration) (*config.Config, []store.Record) {

--- a/internal/scaffold/generate.go
+++ b/internal/scaffold/generate.go
@@ -1,0 +1,300 @@
+package scaffold
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dwarka-prasad/optictrace/internal/suggest"
+)
+
+// Options tunes generation.
+type Options struct {
+	// ServiceName overrides the title from the document.
+	ServiceName string
+	Listen      string
+	Upstream    string
+	// IncludeLow adds Low-confidence name matches (`name`, `first_name`).
+	// Off by default: masking every `name` field in an API produces telemetry
+	// nobody can debug with, and a rule people delete in week one protects
+	// nothing thereafter.
+	IncludeLow bool
+}
+
+// Result is the generated config plus what the generator could not determine.
+type Result struct {
+	YAML string
+	// Notes are things the operator has to check by hand. Surfaced rather than
+	// buried: a scaffolded config that looks finished is worse than one that
+	// admits what it left out.
+	Notes []string
+	// Stats for the summary line.
+	Routes, Rules, MaskedFields int
+}
+
+// authPathHints are route fragments whose payloads are credentials by
+// definition, whatever their schema calls the fields.
+var authPathHints = []string{"/login", "/logout", "/signin", "/sign-in", "/auth",
+	"/token", "/oauth", "/session", "/password", "/register", "/signup"}
+
+// Generate produces a starting optic.yaml.
+func Generate(doc *Document, o Options) *Result {
+	res := &Result{Routes: len(doc.Paths)}
+
+	name := o.ServiceName
+	if name == "" {
+		name = slug(doc.Title)
+	}
+	if name == "" {
+		name = "my-api"
+	}
+
+	var b strings.Builder
+	writeHeader(&b, doc, name, o)
+
+	// --- credential rules, from declared security schemes ------------------
+	// These come first because they are the one thing a spec states rather
+	// than implies, and because a later rule can only add to them.
+	var globalHeaders, globalQueries []string
+	globalHeaders = append(globalHeaders, doc.SecurityHeaders...)
+	globalQueries = append(globalQueries, doc.SecurityQueries...)
+	// Cookie is not usually a declared scheme, but a session cookie in stored
+	// telemetry is a replayable credential wherever it came from.
+	globalHeaders = dedupe(append(globalHeaders, "Cookie"))
+
+	fmt.Fprintf(&b, "rules:\n")
+	fmt.Fprintf(&b, "  # Credentials, from the document's security schemes. This is the part a\n")
+	fmt.Fprintf(&b, "  # specification states outright rather than implies, so it is the part\n")
+	fmt.Fprintf(&b, "  # least likely to be wrong.\n")
+	fmt.Fprintf(&b, "  - name: redact-credentials\n")
+	fmt.Fprintf(&b, "    match:\n      path: \"/**\"\n")
+	fmt.Fprintf(&b, "    redact:\n")
+	fmt.Fprintf(&b, "      headers: [%s]\n", strings.Join(quoteAll(globalHeaders), ", "))
+	if len(globalQueries) > 0 {
+		fmt.Fprintf(&b, "      query_params: [%s]\n", strings.Join(quoteAll(globalQueries), ", "))
+	}
+	res.Rules++
+
+	// --- auth routes: metadata only ----------------------------------------
+	var authGlobs []string
+	for _, p := range doc.Paths {
+		if looksLikeAuth(p.Raw) {
+			authGlobs = append(authGlobs, p.Glob)
+		}
+	}
+	if len(authGlobs) > 0 {
+		fmt.Fprintf(&b, "\n  # Credential exchanges. Capture nothing but metadata: the request body\n")
+		fmt.Fprintf(&b, "  # here IS a password, and no redaction rule is as reliable as not\n")
+		fmt.Fprintf(&b, "  # recording it. Attribution still works — labels read the live request.\n")
+		for _, g := range dedupe(authGlobs) {
+			fmt.Fprintf(&b, "  - name: no-capture-on-%s\n", slug(g))
+			fmt.Fprintf(&b, "    match:\n      path: %q\n", g)
+			fmt.Fprintf(&b, "    restrict: [request_body, response_body, headers]\n")
+			res.Rules++
+		}
+	}
+
+	// --- per-path field redaction ------------------------------------------
+	type finding struct {
+		field string
+		class suggest.Classification
+	}
+	for _, p := range doc.Paths {
+		if looksLikeAuth(p.Raw) {
+			continue // already covered, and more strictly
+		}
+		var found []finding
+		for _, f := range append(append([]string{}, p.RequestFields...), p.ResponseFields...) {
+			c, ok := suggest.ClassifyField(f)
+			if !ok {
+				continue
+			}
+			if c.Confidence == suggest.Low && !o.IncludeLow {
+				continue
+			}
+			found = append(found, finding{field: f, class: c})
+		}
+		// Header and query parameters declared on the path.
+		var hdrs, qrys []string
+		for _, h := range p.HeaderParams {
+			if _, ok := suggest.ClassifyHeader(h); ok {
+				hdrs = append(hdrs, h)
+			}
+		}
+		for _, q := range p.QueryParams {
+			if _, ok := suggest.ClassifyField(q); ok {
+				qrys = append(qrys, q)
+			}
+		}
+		if len(found) == 0 && len(hdrs) == 0 && len(qrys) == 0 {
+			continue
+		}
+
+		sort.Slice(found, func(i, j int) bool { return found[i].field < found[j].field })
+		fmt.Fprintf(&b, "\n  - name: redact-%s\n", slug(p.Glob))
+		fmt.Fprintf(&b, "    match:\n      path: %q\n", p.Glob)
+		fmt.Fprintf(&b, "    redact:\n")
+		if len(hdrs) > 0 {
+			fmt.Fprintf(&b, "      headers: [%s]\n", strings.Join(quoteAll(dedupe(hdrs)), ", "))
+		}
+		if len(qrys) > 0 {
+			fmt.Fprintf(&b, "      query_params: [%s]\n", strings.Join(quoteAll(dedupe(qrys)), ", "))
+		}
+		if len(found) > 0 {
+			fmt.Fprintf(&b, "      json_fields:\n")
+			seen := map[string]bool{}
+			for _, f := range found {
+				// `$.**.` rather than `$.`: the document describes one shape,
+				// but the same object often appears nested inside a wrapper or
+				// echoed back in a response envelope.
+				path := "$.**." + f.field
+				if seen[path] {
+					continue
+				}
+				seen[path] = true
+				fmt.Fprintf(&b, "        - %-34q # %s · %s\n", path, f.class.Confidence, f.class.Why)
+				res.MaskedFields++
+			}
+		}
+		res.Rules++
+	}
+
+	writeFooter(&b, doc)
+	res.YAML = b.String()
+	res.Notes = notes(doc, res, o)
+	return res
+}
+
+func writeHeader(b *strings.Builder, doc *Document, name string, o Options) {
+	kind := "OpenAPI " + doc.Version
+	if doc.Swagger {
+		kind = "Swagger " + doc.Version
+	}
+	fmt.Fprintf(b, `# =============================================================================
+# optic.yaml — GENERATED from a %s document
+# =============================================================================
+# This is a starting point, not a finished policy. It was derived from what the
+# specification DESCRIBES; governance has to hold for what the API actually
+# DOES, and the two differ in ways that matter here:
+#
+#   * A field the document does not model cannot be masked by a rule generated
+#     from it. Free-form objects and additionalProperties are invisible.
+#   * Specifications drift. A field added after this one was written is not here.
+#   * Names lie. A field called "ref" can hold a card number — which is what
+#     'optictrace scan' finds and a name heuristic never will.
+#
+# So: review it, then run the agent and check with real traffic.
+#
+#     optictrace validate -config optic.yaml
+#     optictrace scan -config optic.yaml -window 24h   # after traffic flows
+#
+# Capture is OPT-OUT: everything is recorded unless a rule restricts it. Rules
+# merge top to bottom; later rules win on conflicting capture flags, while
+# redactions and labels accumulate.
+# =============================================================================
+
+version: 1
+
+service:
+  name: %s
+`, kind, name)
+
+	if o.Listen != "" {
+		fmt.Fprintf(b, "  listen: %q\n", o.Listen)
+	} else {
+		fmt.Fprintf(b, "  # listen: \":8080\"        # sidecar mode: where OpticTrace accepts traffic\n")
+	}
+	if o.Upstream != "" {
+		fmt.Fprintf(b, "  upstream: %q\n", o.Upstream)
+	} else {
+		fmt.Fprintf(b, "  # upstream: \"http://localhost:9000\"   # and where it forwards\n")
+	}
+
+	fmt.Fprintf(b, `
+telemetry:
+  admin_listen: "127.0.0.1:9095"   # loopback: this port serves every captured payload
+  metrics:
+    enabled: true
+  store:
+    driver: sqlite
+    dsn: optictrace.db
+    retention_max_age: 720h
+
+`)
+}
+
+func writeFooter(b *strings.Builder, doc *Document) {
+	fmt.Fprintf(b, `
+# -----------------------------------------------------------------------------
+# Worth adding by hand, because a specification cannot tell you:
+#
+#   labels:            who a request belongs to - a tenant header, a plan tier.
+#                      Nothing in a spec says which header identifies a customer.
+#   meter:             numeric usage to bill on, e.g. tokens: "$.usage.total"
+#   sample / keep_*:   volume control on hot routes. keep_errors and
+#                      keep_slower_than rescue the requests worth having.
+# -----------------------------------------------------------------------------
+`)
+}
+
+// notes reports what the generator could not determine. A scaffolded config
+// that looks finished is worse than one that admits what it left out.
+func notes(doc *Document, res *Result, o Options) []string {
+	var out []string
+	if len(doc.SecurityHeaders) == 0 && len(doc.SecurityQueries) == 0 {
+		out = append(out, "The document declares no security schemes, so credential headers were "+
+			"guessed rather than read. Check `redact-credentials` names the header your API "+
+			"actually authenticates with.")
+	}
+	if res.MaskedFields == 0 {
+		out = append(out, "No payload field matched a sensitive-name heuristic. That may be correct, "+
+			"or it may mean the schemas are free-form — a field the document does not model "+
+			"cannot be masked by a rule derived from it.")
+	}
+	if !o.IncludeLow {
+		out = append(out, "Low-confidence matches (name, first_name) were skipped. Re-run with "+
+			"-include-low if this API's personal names need masking.")
+	}
+	out = append(out, "Nothing here restricts capture volume. Add `sample` with `keep_errors` on "+
+		"hot read paths before pointing this at production traffic.")
+	out = append(out, "Run `optictrace scan` once real traffic exists: it reads VALUES, and will "+
+		"find sensitive data in fields whose names gave no clue.")
+	return out
+}
+
+func looksLikeAuth(route string) bool {
+	lower := strings.ToLower(route)
+	for _, hint := range authPathHints {
+		if strings.Contains(lower, hint) {
+			return true
+		}
+	}
+	return false
+}
+
+// slug makes a YAML-safe rule name fragment from a path or title.
+func slug(s string) string {
+	var b strings.Builder
+	lastDash := true
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastDash = false
+		default:
+			if !lastDash {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func quoteAll(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		out = append(out, fmt.Sprintf("%q", s))
+	}
+	return out
+}

--- a/internal/scaffold/generate_test.go
+++ b/internal/scaffold/generate_test.go
@@ -1,0 +1,201 @@
+package scaffold
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dwarka-prasad/optictrace/internal/config"
+)
+
+// The generated file must be one the agent accepts. A scaffolding tool that
+// emits config the agent then refuses is worse than no tool: it teaches people
+// the format is unreliable.
+func mustValidate(t *testing.T, yaml string) *config.Config {
+	t.Helper()
+	cfg, err := config.Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("generated config does not parse: %v\n%s", err, yaml)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("generated config does not validate: %v\n%s", err, yaml)
+	}
+	return cfg
+}
+
+func TestGeneratedConfigIsValid(t *testing.T) {
+	res := Generate(parse(t, openapi3), Options{})
+	cfg := mustValidate(t, res.YAML)
+	if cfg.Service.Name != "acme-payments-api" {
+		t.Errorf("service name = %q", cfg.Service.Name)
+	}
+	if res.Rules < 3 {
+		t.Errorf("only %d rule(s) generated", res.Rules)
+	}
+}
+
+// The single most important field in any payment API, reached the way every
+// payment API actually models it.
+func TestCardNumberIsMasked(t *testing.T) {
+	res := Generate(parse(t, openapi3), Options{})
+	if !strings.Contains(res.YAML, "card.number") {
+		t.Errorf("a nested card number was not masked:\n%s", res.YAML)
+	}
+	if !strings.Contains(res.YAML, "card.cvv") {
+		t.Error("cvv not masked")
+	}
+}
+
+// Redaction paths use `$.**.` because the document describes one shape, but the
+// same object routinely appears nested in a wrapper or echoed in a response.
+func TestRedactionPathsUseRecursiveDescent(t *testing.T) {
+	res := Generate(parse(t, openapi3), Options{})
+	for _, line := range strings.Split(res.YAML, "\n") {
+		l := strings.TrimSpace(line)
+		if strings.HasPrefix(l, `- "$.`) && !strings.HasPrefix(l, `- "$.**.`) {
+			t.Errorf("redaction path is not recursive: %s", l)
+		}
+	}
+}
+
+// A credential exchange is the one place where no redaction rule beats not
+// recording the body at all.
+func TestAuthRoutesAreRestrictedNotRedacted(t *testing.T) {
+	res := Generate(parse(t, openapi3), Options{})
+	cfg := mustValidate(t, res.YAML)
+
+	var found bool
+	for _, r := range cfg.Rules {
+		if strings.Contains(r.Match.Path, "/auth/login") {
+			found = true
+			if len(r.Restrict) == 0 {
+				t.Errorf("the login route is not restricted: %+v", r)
+			}
+		}
+	}
+	if !found {
+		t.Error("no rule was generated for the login route")
+	}
+}
+
+// Declared schemes are the part a spec STATES; guessing over them would throw
+// away the only reliable signal in the document.
+func TestDeclaredSecuritySchemesBecomeRedactions(t *testing.T) {
+	res := Generate(parse(t, openapi3), Options{})
+	for _, want := range []string{"X-Api-Key", "Authorization", "Cookie", "session"} {
+		if !strings.Contains(res.YAML, want) {
+			t.Errorf("declared credential %q is not redacted:\n%s", want, res.YAML)
+		}
+	}
+}
+
+// Masking every `name` field produces telemetry nobody can debug with, and a
+// rule people delete in week one protects nothing afterwards.
+func TestLowConfidenceNamesAreOptIn(t *testing.T) {
+	const withName = `
+openapi: 3.0.0
+info: { title: T, version: "1" }
+paths:
+  /people:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                first_name: { type: string }
+                email: { type: string }
+      responses: { "200": { description: ok } }
+`
+	doc := parse(t, withName)
+
+	off := Generate(doc, Options{})
+	if strings.Contains(off.YAML, "first_name") {
+		t.Error("a low-confidence name was masked by default")
+	}
+	if !strings.Contains(off.YAML, "email") {
+		t.Error("a medium-confidence field should be masked by default")
+	}
+	if !mentions(off.Notes, "Low-confidence") {
+		t.Errorf("the skip must be disclosed: %v", off.Notes)
+	}
+
+	on := Generate(doc, Options{IncludeLow: true})
+	if !strings.Contains(on.YAML, "first_name") {
+		t.Error("-include-low did not mask low-confidence names")
+	}
+}
+
+// A scaffolded config that looks finished is worse than one that admits what it
+// left out.
+func TestNotesDiscloseWhatCouldNotBeDetermined(t *testing.T) {
+	const bare = `
+openapi: 3.0.0
+info: { title: Bare, version: "1" }
+paths:
+  /things:
+    get:
+      responses: { "200": { description: ok } }
+`
+	res := Generate(parse(t, bare), Options{})
+	if !mentions(res.Notes, "no security schemes") {
+		t.Errorf("a document with no declared schemes must say the headers were guessed: %v", res.Notes)
+	}
+	if !mentions(res.Notes, "No payload field matched") {
+		t.Errorf("finding nothing must be reported, not left to look like completeness: %v", res.Notes)
+	}
+	if !mentions(res.Notes, "optictrace scan") {
+		t.Errorf("the notes must point at value-based scanning: %v", res.Notes)
+	}
+	// And the file itself carries the caveat, because notes go to stderr and a
+	// redirect keeps only the file.
+	if !strings.Contains(res.YAML, "starting point") {
+		t.Error("the generated file does not say what it is")
+	}
+}
+
+// Regenerating must produce an identical file, or every run makes a diff and a
+// noisy diff is one nobody reads.
+func TestGenerationIsDeterministic(t *testing.T) {
+	doc := parse(t, openapi3)
+	first := Generate(doc, Options{}).YAML
+	for i := 0; i < 5; i++ {
+		if got := Generate(parse(t, openapi3), Options{}).YAML; got != first {
+			t.Fatal("generation is not stable across runs")
+		}
+	}
+}
+
+func TestSwagger2GeneratesTheSameShape(t *testing.T) {
+	res := Generate(parse(t, swagger2), Options{})
+	mustValidate(t, res.YAML)
+	if !strings.Contains(res.YAML, "card_number") {
+		t.Errorf("swagger body field not masked:\n%s", res.YAML)
+	}
+	if !strings.Contains(res.YAML, "X-Legacy-Key") {
+		t.Error("swagger securityDefinitions not honoured")
+	}
+	if !strings.Contains(res.YAML, "Swagger 2.0") {
+		t.Error("the header should name the document kind it came from")
+	}
+}
+
+func TestServiceListenAndUpstreamOverrides(t *testing.T) {
+	res := Generate(parse(t, openapi3), Options{
+		ServiceName: "custom", Listen: ":8080", Upstream: "http://localhost:9000",
+	})
+	cfg := mustValidate(t, res.YAML)
+	if cfg.Service.Name != "custom" || cfg.Service.Listen != ":8080" ||
+		cfg.Service.Upstream != "http://localhost:9000" {
+		t.Errorf("overrides not applied: %+v", cfg.Service)
+	}
+}
+
+func mentions(list []string, substr string) bool {
+	for _, s := range list {
+		if strings.Contains(s, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/scaffold/parse.go
+++ b/internal/scaffold/parse.go
@@ -1,0 +1,391 @@
+// Package scaffold turns an OpenAPI or Swagger document into a starting
+// optic.yaml.
+//
+// It exists for the bootstrap problem. Today you write governance by hand
+// against an API you may not have written, and you find out what you missed
+// only once traffic flows and `scan` reports it. A spec already lists the
+// routes and the shape of every payload, so most of that first draft can be
+// derived rather than guessed.
+//
+// # What a generated config is, and is not
+//
+// It is a STARTING POINT, and the generated file says so in its own header.
+// A spec describes what an API claims; traffic shows what it does. The two
+// disagree in ways that matter here:
+//
+//   - Undocumented fields are invisible. A payload with `additionalProperties`
+//     or an unmodelled extra key has no entry to match on, and a rule cannot
+//     mask a field the document never mentions.
+//   - Specs drift. A field added last month may not be in the document.
+//   - Names lie. A field called `ref` can hold a card number, which is exactly
+//     what `optictrace scan` catches and a name heuristic cannot.
+//
+// So the output tells the operator to run against real traffic afterwards, and
+// reports what it could not determine rather than quietly producing a
+// confident-looking file.
+package scaffold
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Document is the subset of OpenAPI/Swagger this needs, normalised across
+// versions. Both are parsed into one shape so the generator has a single case
+// to handle rather than a fork at every step.
+type Document struct {
+	Title   string
+	Version string
+	// Paths in document order, normalised.
+	Paths []Path
+	// SecurityHeaders are header and query credential names declared by the
+	// document's security schemes — the most reliable signal in a spec,
+	// because they are stated rather than inferred from a name.
+	SecurityHeaders []string
+	SecurityQueries []string
+	// Swagger reports whether this was a 2.0 document, for the report.
+	Swagger bool
+}
+
+// Path is one route with its methods and payload fields.
+type Path struct {
+	// Raw is the template as written, e.g. /users/{id}.
+	Raw string
+	// Glob is Raw with path parameters replaced by `*`, which is what an
+	// optic.yaml rule matches on.
+	Glob    string
+	Methods []string
+	// RequestFields and ResponseFields are dotted JSON paths into the payload
+	// schemas, e.g. `customer.email`.
+	RequestFields  []string
+	ResponseFields []string
+	// HeaderParams are header parameters declared for this path.
+	HeaderParams []string
+	// QueryParams likewise.
+	QueryParams []string
+}
+
+// maxDepth bounds schema recursion. A self-referencing schema — a Node with
+// children of type Node — would otherwise walk forever, and specs like that are
+// common enough that a scaffolding tool must not be the thing that hangs.
+const maxDepth = 6
+
+// Parse reads an OpenAPI 3.x or Swagger 2.0 document, in YAML or JSON.
+//
+// JSON is a subset of YAML for these purposes, so one parser handles both and
+// the caller does not have to know which they were handed.
+func Parse(raw []byte) (*Document, error) {
+	var root map[string]any
+	if err := yaml.Unmarshal(raw, &root); err != nil {
+		return nil, fmt.Errorf("not a readable OpenAPI or Swagger document: %w", err)
+	}
+	if len(root) == 0 {
+		return nil, fmt.Errorf("document is empty")
+	}
+
+	doc := &Document{}
+	switch {
+	case root["openapi"] != nil:
+		doc.Version = fmt.Sprint(root["openapi"])
+	case root["swagger"] != nil:
+		doc.Version = fmt.Sprint(root["swagger"])
+		doc.Swagger = true
+	default:
+		return nil, fmt.Errorf("document has neither an `openapi` nor a `swagger` version key — " +
+			"is this an API specification?")
+	}
+
+	if info := asMap(root["info"]); info != nil {
+		doc.Title = str(info["title"])
+	}
+
+	p := &parser{root: root, swagger: doc.Swagger}
+	doc.SecurityHeaders, doc.SecurityQueries = p.securityCredentials()
+
+	paths := asMap(root["paths"])
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("document declares no paths — nothing to generate rules for")
+	}
+	// Sorted, so the generated file is stable across runs: a config that
+	// reorders itself produces a diff every time it is regenerated, and a noisy
+	// diff is one nobody reads.
+	for _, route := range sortedKeys(paths) {
+		item := asMap(paths[route])
+		if item == nil {
+			continue
+		}
+		path := Path{Raw: route, Glob: toGlob(route)}
+		for _, method := range []string{"get", "put", "post", "delete", "patch", "head", "options"} {
+			op := asMap(item[method])
+			if op == nil {
+				continue
+			}
+			path.Methods = append(path.Methods, strings.ToUpper(method))
+			p.collectOperation(op, item, &path)
+		}
+		if len(path.Methods) == 0 {
+			continue
+		}
+		path.RequestFields = dedupe(path.RequestFields)
+		path.ResponseFields = dedupe(path.ResponseFields)
+		path.HeaderParams = dedupe(path.HeaderParams)
+		path.QueryParams = dedupe(path.QueryParams)
+		doc.Paths = append(doc.Paths, path)
+	}
+	if len(doc.Paths) == 0 {
+		return nil, fmt.Errorf("document declares paths but none with operations")
+	}
+	return doc, nil
+}
+
+type parser struct {
+	root    map[string]any
+	swagger bool
+	// seen guards against a $ref cycle within one resolution chain.
+	seen map[string]bool
+}
+
+// securityCredentials reads declared security schemes.
+//
+// This is the highest-quality signal a spec offers: an apiKey scheme NAMES the
+// header carrying the credential, so redacting it is a fact rather than a guess
+// about what "x-token" might mean.
+func (p *parser) securityCredentials() (headers, queries []string) {
+	var schemes map[string]any
+	if p.swagger {
+		schemes = asMap(p.root["securityDefinitions"])
+	} else {
+		schemes = asMap(asMap(p.root["components"])["securitySchemes"])
+	}
+	for _, name := range sortedKeys(schemes) {
+		s := asMap(schemes[name])
+		switch strings.ToLower(str(s["type"])) {
+		case "apikey":
+			switch strings.ToLower(str(s["in"])) {
+			case "header":
+				headers = append(headers, str(s["name"]))
+			case "query":
+				queries = append(queries, str(s["name"]))
+			}
+		case "http", "oauth2", "basic":
+			// All of these ride in Authorization.
+			headers = append(headers, "Authorization")
+		}
+	}
+	return dedupe(headers), dedupe(queries)
+}
+
+// collectOperation gathers payload fields and parameters for one operation.
+func (p *parser) collectOperation(op, item map[string]any, out *Path) {
+	// Parameters may be declared on the operation or shared on the path item.
+	for _, src := range []any{op["parameters"], item["parameters"]} {
+		for _, raw := range asSlice(src) {
+			param := p.resolve(asMap(raw))
+			name := str(param["name"])
+			if name == "" {
+				continue
+			}
+			switch strings.ToLower(str(param["in"])) {
+			case "header":
+				out.HeaderParams = append(out.HeaderParams, name)
+			case "query":
+				out.QueryParams = append(out.QueryParams, name)
+			case "body":
+				// Swagger 2.0 puts the request body here.
+				out.RequestFields = append(out.RequestFields,
+					p.fields(asMap(param["schema"]), "", 0)...)
+			}
+		}
+	}
+
+	if p.swagger {
+		// Swagger 2.0 responses carry the schema directly.
+		for _, resp := range asMap(op["responses"]) {
+			r := asMap(resp)
+			out.ResponseFields = append(out.ResponseFields, p.fields(asMap(r["schema"]), "", 0)...)
+		}
+		return
+	}
+
+	// OpenAPI 3.x: requestBody.content.<media>.schema
+	if body := asMap(op["requestBody"]); body != nil {
+		for _, media := range asMap(body["content"]) {
+			m := asMap(media)
+			out.RequestFields = append(out.RequestFields, p.fields(asMap(m["schema"]), "", 0)...)
+		}
+	}
+	for _, resp := range asMap(op["responses"]) {
+		r := asMap(resp)
+		for _, media := range asMap(r["content"]) {
+			m := asMap(media)
+			out.ResponseFields = append(out.ResponseFields, p.fields(asMap(m["schema"]), "", 0)...)
+		}
+	}
+}
+
+// fields walks a schema and returns dotted paths to every leaf property.
+//
+// Arrays are traversed WITHOUT adding an index to the path, because optic.yaml's
+// redaction grammar traverses lists implicitly: `$.items.card` masks the field
+// in every element.
+func (p *parser) fields(schema map[string]any, prefix string, depth int) []string {
+	if schema == nil || depth > maxDepth {
+		return nil
+	}
+	schema = p.resolve(schema)
+	if schema == nil {
+		return nil
+	}
+
+	// Composition keywords: a field is reachable through any branch, so all are
+	// walked. Missing one would leave a documented field unmasked.
+	var out []string
+	for _, key := range []string{"allOf", "anyOf", "oneOf"} {
+		for _, sub := range asSlice(schema[key]) {
+			out = append(out, p.fields(asMap(sub), prefix, depth+1)...)
+		}
+	}
+	if items := asMap(schema["items"]); items != nil {
+		out = append(out, p.fields(items, prefix, depth+1)...)
+	}
+
+	props := asMap(schema["properties"])
+	for _, name := range sortedKeys(props) {
+		path := name
+		if prefix != "" {
+			path = prefix + "." + name
+		}
+		child := p.resolve(asMap(props[name]))
+		if child == nil {
+			out = append(out, path)
+			continue
+		}
+		nested := p.fields(child, path, depth+1)
+		// A leaf contributes itself; a branch contributes its leaves. Emitting
+		// both would produce a rule masking a whole object when only one field
+		// inside it is sensitive.
+		if len(nested) == 0 {
+			out = append(out, path)
+		} else {
+			out = append(out, nested...)
+		}
+	}
+	return out
+}
+
+// resolve follows a local $ref one or more hops.
+func (p *parser) resolve(schema map[string]any) map[string]any {
+	if p.seen == nil {
+		p.seen = map[string]bool{}
+	}
+	for hops := 0; schema != nil && hops < 10; hops++ {
+		ref := str(schema["$ref"])
+		if ref == "" {
+			return schema
+		}
+		if p.seen[ref] {
+			// A cycle. Returning nil ends this branch rather than looping.
+			return nil
+		}
+		p.seen[ref] = true
+		target := p.lookup(ref)
+		delete(p.seen, ref)
+		if target == nil {
+			return nil
+		}
+		schema = target
+	}
+	return schema
+}
+
+// lookup walks a local JSON pointer, e.g. #/components/schemas/Order.
+//
+// Remote refs are deliberately NOT fetched: a scaffolding tool that reaches out
+// to the network to read a URL in a file it was handed is a tool that can be
+// pointed at anything.
+func (p *parser) lookup(ref string) map[string]any {
+	if !strings.HasPrefix(ref, "#/") {
+		return nil
+	}
+	node := any(p.root)
+	for _, seg := range strings.Split(strings.TrimPrefix(ref, "#/"), "/") {
+		seg = strings.ReplaceAll(strings.ReplaceAll(seg, "~1", "/"), "~0", "~")
+		m := asMap(node)
+		if m == nil {
+			return nil
+		}
+		node = m[seg]
+	}
+	return asMap(node)
+}
+
+// toGlob turns /users/{id}/orders into /users/*/orders.
+func toGlob(route string) string {
+	segments := strings.Split(route, "/")
+	for i, s := range segments {
+		if strings.HasPrefix(s, "{") && strings.HasSuffix(s, "}") {
+			segments[i] = "*"
+		}
+	}
+	return strings.Join(segments, "/")
+}
+
+// --- small helpers over the untyped document -------------------------------
+
+func asMap(v any) map[string]any {
+	switch m := v.(type) {
+	case map[string]any:
+		return m
+	case map[any]any:
+		// yaml.v3 produces map[string]any, but a JSON document round-tripped
+		// through some tools can still arrive this way.
+		out := make(map[string]any, len(m))
+		for k, val := range m {
+			out[fmt.Sprint(k)] = val
+		}
+		return out
+	}
+	return nil
+}
+
+func asSlice(v any) []any {
+	if s, ok := v.([]any); ok {
+		return s
+	}
+	return nil
+}
+
+func str(v any) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return fmt.Sprint(v)
+}
+
+func sortedKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func dedupe(in []string) []string {
+	seen := map[string]bool{}
+	out := in[:0]
+	for _, s := range in {
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -1,0 +1,291 @@
+package scaffold
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+const openapi3 = `
+openapi: 3.0.3
+info: { title: Acme Payments API, version: "2.1" }
+components:
+  securitySchemes:
+    apiKey: { type: apiKey, in: header, name: X-Api-Key }
+    sessionQuery: { type: apiKey, in: query, name: session }
+    bearer: { type: http, scheme: bearer }
+  schemas:
+    Card:
+      type: object
+      properties:
+        number: { type: string }
+        cvv: { type: string }
+        expiry: { type: string }
+    Charge:
+      type: object
+      properties:
+        amount: { type: integer }
+        card: { $ref: '#/components/schemas/Card' }
+paths:
+  /api/v1/payments/charge:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/Charge' }
+      responses: { "201": { description: ok } }
+  /api/v1/auth/login:
+    post:
+      responses: { "200": { description: ok } }
+  /api/v1/users/{id}/orders/{orderId}:
+    get:
+      responses: { "200": { description: ok } }
+`
+
+const swagger2 = `
+swagger: "2.0"
+info: { title: Legacy API, version: "1.0" }
+securityDefinitions:
+  key: { type: apiKey, in: header, name: X-Legacy-Key }
+definitions:
+  Payment:
+    type: object
+    properties:
+      card_number: { type: string }
+      customer:
+        type: object
+        properties:
+          email: { type: string }
+paths:
+  /v1/pay:
+    post:
+      parameters:
+        - { name: body, in: body, schema: { $ref: '#/definitions/Payment' } }
+        - { name: X-Trace, in: header, type: string }
+      responses:
+        "200": { schema: { $ref: '#/definitions/Payment' } }
+`
+
+func parse(t *testing.T, doc string) *Document {
+	t.Helper()
+	d, err := Parse([]byte(doc))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return d
+}
+
+func TestParsesOpenAPI3(t *testing.T) {
+	d := parse(t, openapi3)
+	if d.Title != "Acme Payments API" || d.Swagger {
+		t.Errorf("title/version detection: %+v", d)
+	}
+	if len(d.Paths) != 3 {
+		t.Fatalf("paths = %d, want 3", len(d.Paths))
+	}
+	// Declared security schemes are the highest-quality signal a spec offers:
+	// they NAME the credential rather than leaving it to a heuristic.
+	if !contains(d.SecurityHeaders, "X-Api-Key") || !contains(d.SecurityHeaders, "Authorization") {
+		t.Errorf("security headers = %v", d.SecurityHeaders)
+	}
+	if !contains(d.SecurityQueries, "session") {
+		t.Errorf("security query params = %v", d.SecurityQueries)
+	}
+}
+
+// Path templates become globs, or a rule matches nothing: /users/{id} is not a
+// literal route any request has.
+func TestPathTemplatesBecomeGlobs(t *testing.T) {
+	d := parse(t, openapi3)
+	var found string
+	for _, p := range d.Paths {
+		if strings.Contains(p.Raw, "{id}") {
+			found = p.Glob
+		}
+	}
+	if found != "/api/v1/users/*/orders/*" {
+		t.Errorf("glob = %q, want /api/v1/users/*/orders/*", found)
+	}
+}
+
+// $ref must be followed, or every field behind one is invisible — which is
+// most fields in any real specification.
+func TestRefsAreResolvedIntoDottedPaths(t *testing.T) {
+	d := parse(t, openapi3)
+	var fields []string
+	for _, p := range d.Paths {
+		if p.Raw == "/api/v1/payments/charge" {
+			fields = p.RequestFields
+		}
+	}
+	for _, want := range []string{"amount", "card.number", "card.cvv"} {
+		if !contains(fields, want) {
+			t.Errorf("field %q not reached through $ref: %v", want, fields)
+		}
+	}
+	// A branch must contribute its leaves, not itself: emitting `card` too
+	// would generate a rule masking the whole object when one field is
+	// sensitive.
+	if contains(fields, "card") {
+		t.Errorf("intermediate object emitted as a leaf: %v", fields)
+	}
+}
+
+func TestParsesSwagger2(t *testing.T) {
+	d := parse(t, swagger2)
+	if !d.Swagger {
+		t.Error("not detected as Swagger 2.0")
+	}
+	if !contains(d.SecurityHeaders, "X-Legacy-Key") {
+		t.Errorf("securityDefinitions not read: %v", d.SecurityHeaders)
+	}
+	p := d.Paths[0]
+	// Swagger 2.0 puts the request body in `parameters` with in: body, and the
+	// response schema directly on the response.
+	if !contains(p.RequestFields, "card_number") || !contains(p.RequestFields, "customer.email") {
+		t.Errorf("body parameter not walked: %v", p.RequestFields)
+	}
+	if !contains(p.ResponseFields, "card_number") {
+		t.Errorf("response schema not walked: %v", p.ResponseFields)
+	}
+	if !contains(p.HeaderParams, "X-Trace") {
+		t.Errorf("header parameter missed: %v", p.HeaderParams)
+	}
+}
+
+// A self-referencing schema is common (a tree, a comment thread). Walking it
+// must terminate rather than hang the tool.
+func TestRecursiveSchemasTerminate(t *testing.T) {
+	const recursive = `
+openapi: 3.0.0
+info: { title: T, version: "1" }
+components:
+  schemas:
+    Node:
+      type: object
+      properties:
+        email: { type: string }
+        child: { $ref: '#/components/schemas/Node' }
+paths:
+  /tree:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/Node' }
+      responses: { "200": { description: ok } }
+`
+	done := make(chan *Document, 1)
+	go func() { done <- parse(t, recursive) }()
+	select {
+	case d := <-done:
+		if len(d.Paths) != 1 {
+			t.Fatal("no paths")
+		}
+		if !contains(d.Paths[0].RequestFields, "email") {
+			t.Errorf("fields = %v", d.Paths[0].RequestFields)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("parsing a self-referencing schema did not terminate")
+	}
+}
+
+func TestCompositionKeywordsAreWalked(t *testing.T) {
+	const composed = `
+openapi: 3.0.0
+info: { title: T, version: "1" }
+components:
+  schemas:
+    Base: { type: object, properties: { id: { type: string } } }
+    WithSecret: { type: object, properties: { password: { type: string } } }
+paths:
+  /x:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - { $ref: '#/components/schemas/Base' }
+                - { $ref: '#/components/schemas/WithSecret' }
+      responses: { "200": { description: ok } }
+`
+	d := parse(t, composed)
+	// A field reachable through any branch is reachable, so missing one leaves
+	// a documented field unmasked.
+	if !contains(d.Paths[0].RequestFields, "password") {
+		t.Errorf("allOf branch not walked: %v", d.Paths[0].RequestFields)
+	}
+}
+
+func TestArraysDoNotAddIndexesToPaths(t *testing.T) {
+	const arr = `
+openapi: 3.0.0
+info: { title: T, version: "1" }
+paths:
+  /orders:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items:
+                    type: object
+                    properties: { card_number: { type: string } }
+      responses: { "200": { description: ok } }
+`
+	d := parse(t, arr)
+	// optic.yaml traverses lists implicitly, so `items.card_number` masks the
+	// field in every element. An index in the path would match nothing.
+	if !contains(d.Paths[0].RequestFields, "items.card_number") {
+		t.Errorf("array element fields = %v", d.Paths[0].RequestFields)
+	}
+}
+
+func TestBadDocumentsAreRejectedClearly(t *testing.T) {
+	cases := map[string]string{
+		"not a spec at all": "just: some: yaml\n",
+		"empty":             "",
+		"no paths":          "openapi: 3.0.0\ninfo: { title: T, version: '1' }\n",
+		"paths with no ops": "openapi: 3.0.0\ninfo: { title: T, version: '1' }\npaths: { /x: {} }\n",
+	}
+	for name, doc := range cases {
+		if _, err := Parse([]byte(doc)); err == nil {
+			t.Errorf("%s: accepted a document it cannot generate from", name)
+		}
+	}
+}
+
+// Remote refs are not fetched: a scaffolding tool that reaches out to read a
+// URL in a file it was handed is a tool that can be pointed at anything.
+func TestRemoteRefsAreNotFetched(t *testing.T) {
+	const remote = `
+openapi: 3.0.0
+info: { title: T, version: "1" }
+paths:
+  /x:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema: { $ref: 'https://evil.example/schema.json#/Secret' }
+      responses: { "200": { description: ok } }
+`
+	d := parse(t, remote)
+	if len(d.Paths[0].RequestFields) != 0 {
+		t.Errorf("a remote ref produced fields: %v", d.Paths[0].RequestFields)
+	}
+}
+
+func contains(hay []string, needle string) bool {
+	for _, s := range hay {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/suggest/gap_test.go
+++ b/internal/suggest/gap_test.go
@@ -1,0 +1,35 @@
+package suggest
+
+import "testing"
+
+// A card number reached as `card.number` is the single most important field in
+// the table, and it was being missed: the heuristic matched `card_number` but
+// not the `card: { number: ... }` shape every payment API actually uses.
+func TestNestedCardAndAccountNumbers(t *testing.T) {
+	for _, name := range []string{
+		"card.number", "payment.card.number", "card.no", "credit_card.number",
+		"account.number", "bank_account.no",
+	} {
+		c, ok := ClassifyField(name)
+		if !ok {
+			t.Errorf("%q should be classified sensitive", name)
+			continue
+		}
+		if c.Confidence != High {
+			t.Errorf("%q classified %s; a PAN or bank account is high confidence", name, c.Confidence)
+		}
+	}
+}
+
+// The reason this is a PAIR match and not a rule on `number`: a heuristic that
+// flags every number field gets muted, and a muted heuristic protects nothing.
+func TestOrdinaryNumbersAreNotFlagged(t *testing.T) {
+	for _, name := range []string{
+		"order.number", "page.number", "invoice.number", "number",
+		"line.no", "seat.num", "building.number",
+	} {
+		if _, ok := ClassifyField(name); ok {
+			t.Errorf("%q was flagged; over-flagging is how a heuristic gets turned off", name)
+		}
+	}
+}

--- a/internal/suggest/suggest.go
+++ b/internal/suggest/suggest.go
@@ -68,7 +68,42 @@ func exact(names ...string) func(string) bool {
 	}
 }
 
+// nested matches a leaf name whose PARENT segment gives it meaning.
+//
+// `number` on its own is meaningless — an order number, a page number. Under a
+// parent called `card` it is a PAN, and that is the single most important field
+// in this table to catch. Matching the pair is what distinguishes them; a rule
+// on `number` alone would flag everything and be muted, and one on
+// `card_number` alone misses the extremely common `card: { number: ... }`
+// shape that every payment API uses.
+func nested(parents, leaves []string) func(string) bool {
+	return func(name string) bool {
+		segs := strings.Split(strings.ToLower(name), ".")
+		if len(segs) < 2 {
+			return false
+		}
+		leaf, parent := segs[len(segs)-1], segs[len(segs)-2]
+		matches := func(list []string, v string) bool {
+			for _, s := range list {
+				if v == s {
+					return true
+				}
+			}
+			return false
+		}
+		return matches(parents, parent) && matches(leaves, leaf)
+	}
+}
+
 var fieldRules = []nameRule{
+	{nested(
+		[]string{"card", "creditcard", "credit_card", "debitcard", "debit_card", "payment_card", "paymentcard"},
+		[]string{"number", "no", "num", "pan"}), High,
+		"payment card data is PCI-DSS scope"},
+	{nested(
+		[]string{"account", "bank", "bank_account", "bankaccount"},
+		[]string{"number", "no", "num"}), High,
+		"bank account details enable fraud if leaked"},
 	{contains("password", "passwd", "secret", "private_key", "privatekey"), High,
 		"credentials must never be stored in telemetry"},
 	{contains("api_key", "apikey", "access_token", "refresh_token", "auth_token", "bearer"), High,
@@ -108,6 +143,37 @@ var headerRules = []nameRule{
 		"cookies carry session credentials"},
 	{contains("x-forwarded-for", "x-real-ip"), Low,
 		"client IPs are personal data in several jurisdictions"},
+}
+
+// Classification is what the name heuristics concluded about one field or
+// header name.
+type Classification struct {
+	Confidence string
+	Why        string
+}
+
+// ClassifyField reports whether a FIELD name looks sensitive, and why.
+//
+// Exported so that a config generated from an OpenAPI document uses the same
+// table as one suggested from traffic. A second copy of this list would drift
+// from the first, and the drift would be silent — a field masked when a rule
+// was suggested from traffic but not when it was scaffolded from a spec.
+func ClassifyField(name string) (Classification, bool) {
+	return classify(fieldRules, name)
+}
+
+// ClassifyHeader is ClassifyField for header names.
+func ClassifyHeader(name string) (Classification, bool) {
+	return classify(headerRules, name)
+}
+
+func classify(rules []nameRule, name string) (Classification, bool) {
+	for _, r := range rules {
+		if r.match(name) {
+			return Classification{Confidence: r.confidence, Why: r.why}, true
+		}
+	}
+	return Classification{}, false
 }
 
 // Suggestion is one proposed governance change.


### PR DESCRIPTION
Answers the bootstrap problem: today you write `optic.yaml` by hand against an API you may not have written, and find out what you missed once traffic flows and `scan` reports it.

```bash
optictrace init -spec openapi.yaml -out optic.yaml
```

OpenAPI 3.x and Swagger 2.0, YAML or JSON. Output on a realistic payments spec:

```yaml
  - name: redact-credentials          # from declared securitySchemes
    match: { path: "/**" }
    redact:
      headers: ["X-Api-Key", "Authorization", "Cookie"]

  - name: no-capture-on-api-v1-auth-login
    match: { path: "/api/v1/auth/login" }
    restrict: [request_body, response_body, headers]

  - name: redact-api-v1-payments-charge
    match: { path: "/api/v1/payments/charge" }
    redact:
      query_params: ["api_key"]
      json_fields:
        - "$.**.card.number"     # high · payment card data is PCI-DSS scope
        - "$.**.card.cvv"        # high · payment card data is PCI-DSS scope
        - "$.**.customer.email"  # medium · email addresses are personal data
```

## Design points worth reviewing

- **Credential headers come from `securitySchemes`** — the one thing a spec *states* rather than implies, so it's the part least likely to be wrong. Login-shaped routes get `restrict` instead of redaction, because there no rule beats not recording the body.
- **It reuses `suggest`'s name table** rather than copying it. A second copy would drift, and the drift would be silent: a field masked when the rule came from traffic but not when it came from a spec.
- **The generated file leads with what it is not.** A spec describes what an API *claims*. A field the document doesn't model can't be masked by a rule derived from it; specs drift; and a field called `ref` can hold a card number, which is what `scan` finds and no name heuristic will. Caveats go to **stderr**, so `init -spec x.yaml > optic.yaml` still yields a clean file.
- **It validates its own output** before handing it over, and refuses to overwrite an existing config. A scaffolder that emits config the agent then rejects teaches people the format is unreliable.
- **Remote `$ref` URLs are not fetched.** A tool that reads a URL out of a file it was handed is one that can be pointed at anything.

## A real bug this surfaced

**`card.number` was not classified as sensitive.** The heuristics matched `card_number` but not the `card: { number: ... }` shape every payment API actually uses — so the single most important field to mask was being missed, by `optictrace suggest` on **live traffic** as much as by the new scaffolder.

Now matched as a parent/leaf **pair**, deliberately: a rule on `number` alone would flag `order.number` and `page.number`, and a heuristic that flags everything gets muted — at which point it protects nothing. Tests cover both directions.

## Verification

A config generated **from the spec alone**, pointed at live traffic through the agent:

```
card number        redacted     bearer token       redacted
login password     redacted     api key (header)   redacted
customer email     redacted     api key (query)    redacted
phone              redacted     amount 4200        kept, for debugging
```

Plus 19 scaffold checks covering `$ref` through `allOf`, path templates → globs, arrays without indexes, self-referencing schemas terminating, Swagger 2.0's `in: body` and response schemas, deterministic output, and every rejection path. `make lint`, `make test-all`, `-race`, 15/15 rule tests.

## Not included

Labels, meters and sampling are left to the operator, and the generated file says why: nothing in a specification tells you which header identifies a customer, what to bill on, or which routes are hot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
