### PR TITLE
Honour service.trace.response_header in every SDK; canonicalise SDK header names

### DIFF
--- a/README.md
+++ b/README.md
@@ -964,6 +964,13 @@ service:
     response_header: X-Trace-Id   # off by default — returns the id to the caller
 ```
 
+`response_header` is honoured by the proxy **and by every SDK**, which is what
+makes a support conversation start from the customer's screenshot rather than
+from "roughly what time was that?" — a question that, under concurrent traffic,
+identifies the wrong request. The SDKs set it before the handler writes its
+first byte, because a header added after the response is committed is silently
+discarded.
+
 A malformed `traceparent` starts a fresh trace rather than failing anything:
 losing correlation is a nuisance, failing a request over a bad header would be
 a fault.

--- a/examples/springboot-shop/.gitignore
+++ b/examples/springboot-shop/.gitignore
@@ -1,0 +1,5 @@
+target/
+*.db
+*.db-shm
+*.db-wal
+*.log

--- a/examples/springboot-shop/README.md
+++ b/examples/springboot-shop/README.md
@@ -1,0 +1,75 @@
+# springboot-optictrace
+
+A real Spring Boot 3 service instrumented with the OpticTrace **Java servlet
+SDK**, used to check the SDK against an actual servlet container rather than
+against the dynamic proxies in its own test suite.
+
+It is a small shop API: a checkout endpoint that fans out to a catalog read and
+a payment charge, plus a login route and a health check.
+
+```
+POST /api/v1/orders            → GET /api/v1/catalog/{sku}
+                               → POST /api/v1/payments/charge
+POST /api/v1/auth/login
+GET  /api/v1/health            (deliberately ungoverned)
+```
+
+The two inner calls are real HTTP calls back into the same process, so one
+checkout produces three spans. They join into one trace because
+`CheckoutController` copies `TraceContext.outboundHeaders()` onto each outbound
+request — that is the only tracing code in the application.
+
+## Running it
+
+All paths below are relative to this directory.
+
+```bash
+# 1. build and install the SDK into the local Maven repo (it is not on Central)
+(cd ../../sdks/java && mvn install -DskipTests)
+
+# 2. the agent, in collector mode — no proxy, it only stores and aggregates
+../../bin/optictrace run -config optic.yaml -ui ../../ui/out
+
+# 3. the application
+mvn package -DskipTests
+java -jar target/springboot-optictrace-1.0.0.jar
+
+# 4. traffic: several tenants, a mix of routes, some failures
+./drive-traffic.sh 80
+```
+
+Dashboard: <http://127.0.0.1:9095>
+
+## What it demonstrates
+
+| | |
+|---|---|
+| **In-process redaction** | The card number and CVV are masked inside the JVM that saw them. `4111111111111111` never reaches the agent, on either hop. |
+| **Correlation** | The three legs of a checkout share a trace id, and the two inner legs name the outer one as parent. Never matched by timestamp. |
+| **Application logs** | `PaymentsController` logs the raw card number at FINE, the way a service does while someone is debugging. It is stored `[REDACTED]`, filed against the exact span that wrote it. |
+| **Attribution** | `X-Tenant-ID` / `X-Region` / `X-Plan` become labels, forwarded across the internal hops so the usage page bills the whole trace, not just its first leg. |
+| **Sampling** | Catalog reads are sampled at 0.4, with `keep_slower_than: 200ms`. The record is always written; only the body is sampled. |
+| **Trace id to the caller** | Responses carry `X-Trace-Id`, so a support conversation can start from a screenshot instead of a timestamp. |
+
+## Wiring
+
+All of it is in [`OpticTraceConfig`](src/main/java/com/example/shop/OpticTraceConfig.java):
+a `FilterRegistrationBean` at `HIGHEST_PRECEDENCE` so the filter sees the bytes
+the client sent, and an `OpticTraceLogHandler` on the `com.example.shop` logger.
+
+One non-obvious detail: JUL filters on the **logger** level before a handler is
+ever consulted, and its default is `INFO`. Without `setLevel(Level.FINE)` the
+masked debug line would never be shipped — and the demo would look like
+redaction was working when in fact nothing had been sent.
+
+## Governance review
+
+```bash
+../../bin/optictrace scan    -config optic.yaml -window 1h   # inspects values
+../../bin/optictrace suggest -config optic.yaml -window 1h   # inspects names
+```
+
+`scan` reports clean. `suggest` still proposes masking `$.customer.name` and
+`$.name` on the catalog — both left in place on purpose, so the example has a
+real finding to look at rather than a contrived one. `/api/v1/health` is
+ungoverned for the same reason.

--- a/examples/springboot-shop/drive-traffic.sh
+++ b/examples/springboot-shop/drive-traffic.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Drives realistic traffic through the shop so the dashboard has something to
+# show: several tenants, a mix of routes, and enough failures to make the
+# error rate and the tail-sampling rules meaningful.
+set -u
+BASE=${BASE:-http://127.0.0.1:8080}
+N=${1:-60}
+
+TENANTS=(acme globex initech hooli)
+REGIONS=(ap-south-1 us-east-1 eu-west-1)
+PLANS=(free growth enterprise)
+SKUS=(SKU-100 SKU-200 SKU-300 SKU-400 SKU-999)
+
+hdr() {
+  local t=${TENANTS[$((RANDOM % ${#TENANTS[@]}))]}
+  local r=${REGIONS[$((RANDOM % ${#REGIONS[@]}))]}
+  local p=${PLANS[$((RANDOM % ${#PLANS[@]}))]}
+  printf -- "-H X-Tenant-ID:%s -H X-Region:%s -H X-Plan:%s" "$t" "$r" "$p"
+}
+
+for i in $(seq 1 "$N"); do
+  sku=${SKUS[$((RANDOM % ${#SKUS[@]}))]}
+  h=$(hdr)
+  case $((RANDOM % 10)) in
+    0|1|2|3)
+      # Checkout: three spans per call, and the only route carrying card data.
+      qty=$((RANDOM % 4 + 1))
+      curl -s -o /dev/null $h \
+        -H 'Content-Type: application/json' \
+        -H 'Authorization: Bearer sk_live_do_not_log_me' \
+        -X POST "$BASE/api/v1/orders?channel=web" \
+        -d "{\"sku\":\"$sku\",\"qty\":$qty,\"customer\":{\"name\":\"Test $i\",\"email\":\"buyer$i@example.com\",\"phone\":\"+91-90000000$((i % 100))\"},\"card\":{\"number\":\"4111111111111111\",\"cvv\":\"312\",\"holder\":\"TEST BUYER\"}}"
+      ;;
+    4|5|6|7)
+      curl -s -o /dev/null $h "$BASE/api/v1/catalog/$sku"
+      ;;
+    8)
+      curl -s -o /dev/null $h -H 'Content-Type: application/json' \
+        -X POST "$BASE/api/v1/auth/login" \
+        -d '{"username":"buyer","password":"hunter2"}'
+      ;;
+    9)
+      curl -s -o /dev/null "$BASE/api/v1/health"
+      ;;
+  esac
+done
+echo "sent $N requests to $BASE"

--- a/examples/springboot-shop/optic.yaml
+++ b/examples/springboot-shop/optic.yaml
@@ -1,0 +1,119 @@
+# =============================================================================
+# Governance for the Spring Boot shop — one policy, evaluated in-process.
+# =============================================================================
+# The application loads THIS file through the servlet SDK and governs itself:
+# a card number is masked inside the JVM that saw it and never crosses a
+# process boundary in the clear. Only the already-governed record is shipped.
+#
+# The agent loads the same file and runs in COLLECTOR mode — no service.listen,
+# no upstream, because nothing is being proxied. It stores, aggregates, and
+# serves the dashboard.
+version: 1
+
+service:
+  name: shop-api
+  trace:
+    response_header: X-Trace-Id
+
+telemetry:
+  admin_listen: "127.0.0.1:9095"
+  console_log: false
+  metrics:
+    enabled: true
+    max_label_values: 500
+  store:
+    driver: sqlite
+    dsn: shop.db
+    retention_max_rows: 200000
+  app_logs:
+    enabled: true
+    level_min: debug        # so the masked FINE line is visible in the demo
+    max_lines_per_span: 200
+    max_message_bytes: 8192
+    retention_max_age: 168h
+    drop_orphans: true
+    redact:
+      # Single-quoted: YAML double quotes reject escapes like \s.
+      patterns:
+        - 'Bearer\s+\S+'
+        - '\b\d{13,19}\b'                 # card-shaped digit runs
+        - '[\w.+-]+@[\w-]+\.[\w.]+'       # email addresses
+      fields: [authorization, password, card_number, email]
+  billing:
+    consumer_label: tenant
+    currency: USD
+    prices:
+      per_request: 0.0002
+      per_gb: 0.05
+      per_meter_unit:
+        order_value: 0.001
+
+defaults:
+  capture:
+    request_body: true
+    response_body: true
+    headers: true
+
+rules:
+  # Checkout carries the card and the customer. Mask both; keep everything
+  # else, because an order you cannot inspect is an order you cannot support.
+  - name: redact-checkout-secrets
+    match:
+      path: "/api/v1/orders"
+      methods: [POST]
+    redact:
+      headers: [Authorization, Cookie]
+      json_fields:
+        - "$.card.number"
+        - "$.card.cvv"
+        - "$.customer.email"
+        - "$.customer.phone"      # added after `optictrace suggest` flagged it
+        - "$.**.card.number"
+        - "$.**.card.cvv"
+    meter:
+      order_value: "$.amount"
+    labels:
+      tenant:  "header:X-Tenant-ID"
+      region:  "header:X-Region|^([a-z]{2})-"   # ap-south-1 -> ap
+      channel: "query:channel"
+      plan:    "header:X-Plan"
+
+  # The payment leg, called from checkout inside the same JVM over HTTP.
+  # Same secrets, different hop — and a hop the client never sees.
+  - name: redact-payment-leg
+    match:
+      path: "/api/v1/payments/**"
+    redact:
+      headers: [Authorization]
+      json_fields:
+        - "$.card.number"
+        - "$.card.cvv"
+        - "$.**.card.number"
+        - "$.**.card.cvv"
+    labels:
+      tenant: "header:X-Tenant-ID"
+      region: "header:X-Region|^([a-z]{2})-"
+
+  # Credentials must never reach telemetry — metadata only. The tenant label
+  # still resolves, because attribution and capture are independent.
+  - name: no-capture-on-login
+    match:
+      path: "/api/v1/auth/login"
+    restrict: [request_body, response_body, headers]
+    labels:
+      tenant: "header:X-Tenant-ID"
+
+  # Catalog reads are the hot path: sample them, but never lose an error and
+  # never lose a slow one.
+  - name: sample-catalog-reads
+    match:
+      path: "/api/v1/catalog/**"
+      methods: [GET]
+    sample: 0.4
+    keep_errors: true
+    keep_slower_than: 200ms
+    labels:
+      tenant: "header:X-Tenant-ID"
+
+  # NOTE: /api/v1/health is deliberately ungoverned, so `optictrace scan` and
+  # `optictrace suggest` have something real to find in this example.

--- a/examples/springboot-shop/pom.xml
+++ b/examples/springboot-shop/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.3.4</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>com.example</groupId>
+  <artifactId>springboot-optictrace</artifactId>
+  <version>1.0.0</version>
+  <name>Spring Boot + OpticTrace</name>
+  <description>
+    A small shop API used to exercise the OpticTrace Java SDK in a real Spring
+    Boot application: governance in-process, traces across internal calls, and
+    application logs filed under the request that wrote them.
+  </description>
+
+  <properties>
+    <java.version>21</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+
+    <!-- The OpticTrace servlet SDK. Installed to the local repository from
+         ../../sdks/java with `mvn install`; it is not on Maven Central
+         yet. -->
+    <dependency>
+      <groupId>io.github.dwarka-prasad</groupId>
+      <artifactId>optictrace-servlet</artifactId>
+      <version>0.10.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/examples/springboot-shop/src/main/java/com/example/shop/CatalogController.java
+++ b/examples/springboot-shop/src/main/java/com/example/shop/CatalogController.java
@@ -1,0 +1,45 @@
+package com.example.shop;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import java.util.logging.Logger;
+
+/** Product lookups — the hot, sampled read path. */
+@RestController
+public class CatalogController {
+
+    private static final Logger log = Logger.getLogger("com.example.shop.catalog");
+
+    @GetMapping("/api/v1/catalog/{sku}")
+    public ResponseEntity<?> product(@PathVariable String sku) throws InterruptedException {
+        log.fine("catalog lookup for " + sku);
+        Model.Product p = Model.catalog().get(sku);
+        if (p == null) {
+            // An error worth keeping even on a sampled route — that is what
+            // keep_errors is for.
+            log.warning("unknown sku requested: " + sku);
+            return ResponseEntity.status(404).body(Map.of("error", "no such product"));
+        }
+        if ("SKU-200".equals(sku) && Math.random() < 0.3) {
+            // A slow tail, so keep_slower_than has something to rescue and the
+            // latency percentiles are not a flat line.
+            Thread.sleep(250);
+            log.warning("slow catalog read for " + sku + " (cold cache)");
+        }
+        if (p.stock() == 0) {
+            log.info("product out of stock: " + sku);
+        }
+        return ResponseEntity.ok(p);
+    }
+
+    @GetMapping("/api/v1/health")
+    public Map<String, Object> health() {
+        // Deliberately ungoverned by optic.yaml — this is what `optictrace scan`
+        // and `suggest` exist to notice.
+        return Map.of("ok", true, "service", "shop-api");
+    }
+}

--- a/examples/springboot-shop/src/main/java/com/example/shop/CheckoutController.java
+++ b/examples/springboot-shop/src/main/java/com/example/shop/CheckoutController.java
@@ -1,0 +1,103 @@
+package com.example.shop;
+
+import io.github.dwarkaprasad.optictrace.TraceContext;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * The composite endpoint: one inbound call fans out to catalog and payments.
+ *
+ * <p>Those two legs are real HTTP calls back into this same process, so the
+ * agent records three spans per checkout. They share a trace id only because
+ * {@link TraceContext#outboundHeaders()} is copied onto each outbound request —
+ * that is the whole contribution the application has to make.
+ */
+@RestController
+public class CheckoutController {
+
+    private static final Logger log = Logger.getLogger("com.example.shop.checkout");
+
+    private final RestTemplate http;
+    private final HttpServletRequest inbound;
+
+    public CheckoutController(RestTemplate http, HttpServletRequest inbound) {
+        this.http = http;
+        this.inbound = inbound;   // a Spring request-scoped proxy
+    }
+
+    @PostMapping("/api/v1/orders")
+    public ResponseEntity<?> createOrder(@RequestBody Model.OrderRequest req) {
+        TraceContext ctx = TraceContext.current();
+        log.info("order received for " + req.sku() + " x" + req.qty()
+                + (ctx == null ? "" : " (trace " + ctx.traceId + ")"));
+
+        Model.Product product;
+        try {
+            product = http.exchange(
+                    "http://127.0.0.1:8080/api/v1/catalog/" + req.sku(),
+                    HttpMethod.GET, new HttpEntity<>(propagate()), Model.Product.class).getBody();
+        } catch (HttpStatusCodeException e) {
+            log.warning("catalog rejected sku " + req.sku() + ": " + e.getStatusCode());
+            return ResponseEntity.status(404).body(Map.of("error", "unknown sku", "sku", req.sku()));
+        }
+
+        if (product == null || product.stock() < req.qty()) {
+            log.warning("insufficient stock for " + req.sku());
+            return ResponseEntity.status(409).body(Map.of("error", "out of stock", "sku", req.sku()));
+        }
+
+        double amount = product.price() * req.qty();
+        String orderRef = "ord_" + Math.abs(req.customer().email().hashCode() % 100000);
+        log.info("charging " + amount + " for " + orderRef);
+
+        ResponseEntity<Map> charge;
+        try {
+            charge = http.exchange(
+                    "http://127.0.0.1:8080/api/v1/payments/charge", HttpMethod.POST,
+                    new HttpEntity<>(new Model.ChargeRequest(amount, req.card(), orderRef), propagate()),
+                    Map.class);
+        } catch (HttpStatusCodeException e) {
+            log.severe("payment failed for " + orderRef + ": " + e.getStatusCode());
+            return ResponseEntity.status(e.getStatusCode())
+                    .body(Map.of("error", "payment failed", "order_ref", orderRef));
+        }
+
+        log.info("order confirmed: " + orderRef);
+        return ResponseEntity.status(201).body(Map.of(
+                "order_ref", orderRef,
+                "sku", product.sku(),
+                "qty", req.qty(),
+                "amount", amount,
+                "charge", charge.getBody()));
+    }
+
+    /**
+     * Copies the current span onto an outbound call so the legs join up, plus
+     * the tenant context.
+     *
+     * <p>The trace headers are what OpticTrace needs; the tenant headers are
+     * what the {@code labels:} block in optic.yaml reads. Without them the
+     * inner legs record with an empty tenant, so the usage page bills the
+     * customer for the checkout but not for the work the checkout caused.
+     */
+    private HttpHeaders propagate() {
+        HttpHeaders h = new HttpHeaders();
+        TraceContext.outboundHeaders().forEach(h::set);
+        for (String name : new String[]{"X-Tenant-ID", "X-Region", "X-Plan"}) {
+            String v = inbound.getHeader(name);
+            if (v != null) h.set(name, v);
+        }
+        return h;
+    }
+}

--- a/examples/springboot-shop/src/main/java/com/example/shop/Model.java
+++ b/examples/springboot-shop/src/main/java/com/example/shop/Model.java
@@ -1,0 +1,27 @@
+package com.example.shop;
+
+import java.util.Map;
+
+/** Request and response shapes for the shop API. */
+public class Model {
+
+    public record Card(String number, String cvv, String holder) {}
+
+    public record Customer(String name, String email, String phone) {}
+
+    public record OrderRequest(String sku, int qty, Customer customer, Card card) {}
+
+    public record ChargeRequest(double amount, Card card, String orderRef) {}
+
+    public record LoginRequest(String username, String password) {}
+
+    public record Product(String sku, String name, double price, int stock) {}
+
+    public static Map<String, Product> catalog() {
+        return Map.of(
+                "SKU-100", new Product("SKU-100", "Mechanical keyboard", 129.00, 42),
+                "SKU-200", new Product("SKU-200", "27\" monitor", 349.00, 7),
+                "SKU-300", new Product("SKU-300", "Desk lamp", 39.50, 0),
+                "SKU-400", new Product("SKU-400", "USB-C dock", 189.00, 15));
+    }
+}

--- a/examples/springboot-shop/src/main/java/com/example/shop/OpticTraceConfig.java
+++ b/examples/springboot-shop/src/main/java/com/example/shop/OpticTraceConfig.java
@@ -1,0 +1,75 @@
+package com.example.shop;
+
+import io.github.dwarkaprasad.optictrace.OpticTraceFilter;
+import io.github.dwarkaprasad.optictrace.OpticTraceLogHandler;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * The only OpticTrace-aware code in this application.
+ *
+ * <p>Everything else — the controllers, their logging, their internal calls —
+ * is ordinary Spring. That is the point: governance, correlation and log
+ * shipping are wired once here rather than remembered at every call site.
+ */
+@Configuration
+public class OpticTraceConfig {
+
+    @Value("${optictrace.agent}")
+    private String agentUrl;
+
+    @Value("${optictrace.config}")
+    private String configPath;
+
+    @Value("${optictrace.service}")
+    private String serviceName;
+
+    /**
+     * Registers the filter FIRST in the chain, so what it records is what the
+     * client actually sent and received. A filter further down would see a
+     * request other filters had already rewritten.
+     */
+    @Bean
+    public FilterRegistrationBean<OpticTraceFilter> optictrace() throws IOException {
+        FilterRegistrationBean<OpticTraceFilter> reg = new FilterRegistrationBean<>(
+                new OpticTraceFilter(configPath, agentUrl, serviceName));
+        reg.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        reg.addUrlPatterns("/*");
+        return reg;
+    }
+
+    /**
+     * Ships whatever the application logs to the agent, correlated to the span
+     * being served.
+     *
+     * <p>Attached to the root JUL logger because Spring Boot routes its
+     * logging through SLF4J to Logback by default; the jul-to-slf4j bridge in
+     * spring-boot-starter-logging means the reverse handler here still sees
+     * records from java.util.logging. Controllers in this app log through JUL
+     * directly, which keeps the demo honest about what the handler receives.
+     */
+    @PostConstruct
+    public void installLogShipping() {
+        Logger parent = Logger.getLogger("com.example.shop");
+        // JUL filters on the LOGGER level before a handler is ever consulted,
+        // and its default is INFO — without this the masked FINE line in
+        // PaymentsController would never be shipped, and the demo would look
+        // like redaction worked when nothing had been sent.
+        parent.setLevel(Level.FINE);
+        parent.addHandler(new OpticTraceLogHandler(agentUrl, serviceName));
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/examples/springboot-shop/src/main/java/com/example/shop/PaymentsController.java
+++ b/examples/springboot-shop/src/main/java/com/example/shop/PaymentsController.java
@@ -1,0 +1,49 @@
+package com.example.shop;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.logging.Logger;
+
+/** The leg that handles card data. */
+@RestController
+public class PaymentsController {
+
+    private static final Logger log = Logger.getLogger("com.example.shop.payments");
+
+    @PostMapping("/api/v1/payments/charge")
+    public ResponseEntity<?> charge(@RequestBody Model.ChargeRequest req) throws InterruptedException {
+        // A real service logs like this while debugging and forgets to take it
+        // out. The line is stored REDACTED — that is the point of running logs
+        // through the same policy as payloads.
+        log.fine("charging card " + req.card().number() + " for " + req.amount());
+        log.info("charge requested for " + req.orderRef());
+
+        Thread.sleep(ThreadLocalRandom.current().nextInt(10, 50));
+
+        if (req.amount() > 900 && Math.random() < 0.5) {
+            log.severe("charge declined: limit_exceeded for " + req.orderRef());
+            return ResponseEntity.status(402).body(Map.of("status", "declined", "reason", "limit_exceeded"));
+        }
+        if (Math.random() < 0.06) {
+            log.severe("payment gateway unreachable (acquirer-eu)");
+            return ResponseEntity.status(502).body(Map.of("status", "error", "reason", "gateway"));
+        }
+
+        String chargeId = "ch_" + ThreadLocalRandom.current().nextInt(10000, 99999);
+        log.info("charge captured: " + chargeId);
+        return ResponseEntity.ok(Map.of("status", "captured", "charge_id", chargeId, "amount", req.amount()));
+    }
+
+    @PostMapping("/api/v1/auth/login")
+    public Map<String, String> login(@RequestBody Model.LoginRequest req) {
+        // Nothing here may be captured — but the tenant label still resolves,
+        // so the request is still attributable for billing.
+        log.info("login attempt for " + req.username());
+        return Map.of("token", "session-token-abc123");
+    }
+}

--- a/examples/springboot-shop/src/main/java/com/example/shop/ShopApplication.java
+++ b/examples/springboot-shop/src/main/java/com/example/shop/ShopApplication.java
@@ -1,0 +1,11 @@
+package com.example.shop;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ShopApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(ShopApplication.class, args);
+    }
+}

--- a/examples/springboot-shop/src/main/resources/application.yml
+++ b/examples/springboot-shop/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+server:
+  port: 8080
+
+logging:
+  level:
+    com.example.shop: DEBUG
+  pattern:
+    console: "%d{HH:mm:ss} %-5level %logger{20} - %msg%n"
+
+optictrace:
+  # Where the agent's admin API listens. The agent runs in collector mode: it
+  # proxies nothing, because the SDK is already in the request path.
+  agent: http://127.0.0.1:9095
+  config: optic.yaml
+  service: shop-api

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -795,6 +795,16 @@ func (s *Server) ingest(w http.ResponseWriter, r *http.Request) {
 	if rec.Route == "" {
 		rec.Route = rec.Path
 	}
+	// Canonicalise header NAMES so a record from an SDK compares equal to one
+	// from the proxy. Go's http.Header is already canonical (Authorization);
+	// an SDK hands over whatever the wire carried, which for HTTP/2 is always
+	// lower case. Without this `optictrace suggest` reports a header its own
+	// rule already masks, because the coverage lookup is keyed on the
+	// canonical name — advice to add a rule you already have is worse than no
+	// advice. Names only: the values were governed in-process and are not
+	// touched here.
+	rec.RequestHeaders = canonicalHeaderNames(rec.RequestHeaders)
+	rec.ResponseHeaders = canonicalHeaderNames(rec.ResponseHeaders)
 	if s.Collector != nil {
 		s.Collector.SDKIngested()
 		s.Collector.Observe(metrics.Observation{
@@ -815,6 +825,24 @@ func (s *Server) ingest(w http.ResponseWriter, r *http.Request) {
 		s.Dispatcher.Enqueue(&rec)
 	}
 	w.WriteHeader(http.StatusAccepted)
+}
+
+// canonicalHeaderNames rewrites map keys to http.Header's canonical form.
+// On a collision the value already stored wins, so a record carrying both
+// "authorization" and "Authorization" cannot have a masked value replaced by
+// an unmasked one through map iteration order.
+func canonicalHeaderNames(h map[string]string) map[string]string {
+	if h == nil {
+		return nil
+	}
+	out := make(map[string]string, len(h))
+	for name, val := range h {
+		k := http.CanonicalHeaderKey(name)
+		if _, exists := out[k]; !exists {
+			out[k] = val
+		}
+	}
+	return out
 }
 
 // ui serves the embedded dashboard build when present, falling back to a

--- a/internal/admin/ingest_test.go
+++ b/internal/admin/ingest_test.go
@@ -1,0 +1,88 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dwarka-prasad/optictrace/internal/store"
+)
+
+// An SDK sends whatever header names the wire carried — lower case under
+// HTTP/2, and lower case from every SDK this project ships. The proxy stores
+// Go's canonical form. If the agent kept both spellings, `optictrace suggest`
+// would report "authorization is a credential" on a route whose own rule
+// already masks it, because its coverage lookup is keyed on the canonical
+// name. That is worse than silence: it teaches people to ignore the tool.
+func TestIngestCanonicalisesHeaderNamesFromSDKs(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "a.db")
+	st, err := store.NewSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	// Close() drains outstanding records and then closes the store, so it is
+	// called exactly once — at the point the test needs the record readable.
+	w := store.NewAsyncWriter(st, 16, slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
+
+	s := &Server{Reader: st, Writer: w, HealthOpen: true, Version: "test"}
+	body, _ := json.Marshal(map[string]any{
+		"time": time.Now().Format(time.RFC3339Nano), "service": "shop-api",
+		"method": "POST", "path": "/api/v1/orders", "route": "/api/v1/orders",
+		"status": 201, "duration_ms": 1.0, "source": "java",
+		"request_headers":  map[string]string{"authorization": "[REDACTED]", "x-tenant-id": "acme"},
+		"response_headers": map[string]string{"content-type": "application/json"},
+	})
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, httptest.NewRequest("POST", "/api/ingest", bytes.NewReader(body)))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("ingest status %d: %s", rec.Code, rec.Body.String())
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+
+	reopened, err := store.NewSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer reopened.Close()
+	got, err := reopened.Recent(context.Background(), time.Now().Add(-time.Hour), 1)
+	if err != nil || len(got) != 1 {
+		t.Fatalf("recent: %v (%d records)", err, len(got))
+	}
+	for name, want := range map[string]string{
+		"Authorization": "[REDACTED]",
+		"X-Tenant-Id":   "acme",
+	} {
+		if got[0].RequestHeaders[name] != want {
+			t.Errorf("request header %q = %q, want %q (headers: %v)",
+				name, got[0].RequestHeaders[name], want, got[0].RequestHeaders)
+		}
+	}
+	if got[0].ResponseHeaders["Content-Type"] != "application/json" {
+		t.Errorf("response headers not canonicalised: %v", got[0].ResponseHeaders)
+	}
+}
+
+// A record carrying the same header twice under different spellings must not
+// lose the masked value to map iteration order.
+func TestCanonicalHeaderNamesKeepsFirstOnCollision(t *testing.T) {
+	for i := 0; i < 200; i++ { // map order is randomised; one pass proves nothing
+		out := canonicalHeaderNames(map[string]string{
+			"authorization": "[REDACTED]",
+			"Authorization": "[REDACTED]",
+		})
+		if len(out) != 1 || out["Authorization"] != "[REDACTED]" {
+			t.Fatalf("collision handling: %v", out)
+		}
+	}
+	if canonicalHeaderNames(nil) != nil {
+		t.Error("nil must stay nil, so an absent header map is not stored as an empty one")
+	}
+}

--- a/sdks/express/engine.js
+++ b/sdks/express/engine.js
@@ -48,6 +48,10 @@ class Engine {
       throw new Error(`optic.yaml: unsupported version ${cfg && cfg.version} (expected 1)`);
     }
     this.serviceName = cfg.service?.name ?? '';
+    // The only thread from a customer's screenshot back to the record.
+    // Without it a support conversation starts at "roughly what time?", which
+    // under concurrency identifies the wrong request.
+    this.traceResponseHeader = cfg.service?.trace?.response_header ?? '';
     const cap = cfg.defaults?.capture ?? {};
     this.defaults = {
       request_body: cap.request_body !== false,

--- a/sdks/express/index.js
+++ b/sdks/express/index.js
@@ -47,6 +47,7 @@ function optictrace(options = {}) {
       engine.rules = next.rules;
       engine.defaults = next.defaults;
       engine.captureLimit = next.captureLimit;
+      engine.traceResponseHeader = next.traceResponseHeader;
     } catch (e) {
       onError(e);
     }
@@ -56,6 +57,12 @@ function optictrace(options = {}) {
     // Adopt the caller's trace or start one, and publish it before the
     // application runs so its logs and outbound calls can name this span.
     const ctx = trace.fromHeader(req.headers[trace.HEADER]);
+    // Echo the trace id back to the caller, if configured. Set BEFORE the
+    // handler runs: once it writes a byte the headers are flushed and a later
+    // setHeader throws ERR_HTTP_HEADERS_SENT.
+    if (engine.traceResponseHeader) {
+      res.setHeader(engine.traceResponseHeader, ctx.traceId);
+    }
     const start = process.hrtime.bigint();
     const policy = engine.evaluate(req.method, req.path ?? req.url.split('?')[0]);
     // The up-front draw. Tail-based rules can rescue a request this draw

--- a/sdks/express/package.json
+++ b/sdks/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optictrace/express",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "OpticTrace middleware for Express — config-driven API telemetry & governance",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/sdks/express/test/smoke.test.js
+++ b/sdks/express/test/smoke.test.js
@@ -15,6 +15,8 @@ const CONFIG = `
 version: 1
 service:
   name: express-test
+  trace:
+    response_header: X-Trace-Id
 rules:
   - name: no-capture-on-auth
     match: { path: "/auth/**" }
@@ -124,6 +126,11 @@ async function main() {
   });
   assert.strictEqual(r1.status, 201);
   const body1 = await r1.json();
+  // The only thread from a customer's screenshot back to the record. The Go
+  // proxy has always echoed it; the SDKs silently ignored the setting until a
+  // real app was pointed at one.
+  const echoedTraceId = r1.headers.get('x-trace-id');
+  assert.match(echoedTraceId ?? '', /^[0-9a-f]{32}$/, 'trace id not echoed to the caller');
   assert.strictEqual(body1.echo.card.number, '4111111111111111', 'traffic must not be mutated');
 
   await fetch(`${base}/auth/login`, {
@@ -145,6 +152,8 @@ async function main() {
   const pay = emitted.find((e) => e.path === '/payments/charge');
   const auth = emitted.find((e) => e.path === '/auth/login');
   assert.ok(pay && auth, 'both records emitted');
+
+  assert.strictEqual(pay.trace_id, echoedTraceId, 'echoed header names a different trace than the record');
 
   const payStr = JSON.stringify(pay);
   assert.ok(!payStr.includes('4111111111111111'), 'card number leaked into telemetry');

--- a/sdks/fastapi/optictrace_fastapi/__init__.py
+++ b/sdks/fastapi/optictrace_fastapi/__init__.py
@@ -59,6 +59,7 @@ class OpticTraceMiddleware:
         with open(config_path, encoding="utf-8") as f:
             self.engine = Engine(yaml.safe_load(f))
         self.service = service_name or self.engine.service_name
+        self.trace_response_header = self.engine.trace_response_header
         self.ingest_url = agent_url.rstrip("/") + "/api/ingest" if agent_url else None
         self.console_log = console_log
         # Delivery counters. The previous version swallowed every failure with
@@ -128,6 +129,18 @@ class OpticTraceMiddleware:
         async def tee_send(message):
             if message["type"] == "http.response.start":
                 state["status"] = message["status"]
+                # Echo the trace id back to the caller, if configured. Injected
+                # into the start message rather than set afterwards: in ASGI
+                # the headers go out with this message and there is no later
+                # point at which one can be added.
+                if self.trace_response_header:
+                    message = dict(message)
+                    message["headers"] = list(message.get("headers", [])) + [
+                        (
+                            self.trace_response_header.lower().encode("latin-1"),
+                            ctx.trace_id.encode("latin-1"),
+                        )
+                    ]
                 state["resp_headers"] = {
                     k.decode("latin-1"): v.decode("latin-1")
                     for k, v in message.get("headers", [])

--- a/sdks/fastapi/optictrace_fastapi/engine.py
+++ b/sdks/fastapi/optictrace_fastapi/engine.py
@@ -284,6 +284,12 @@ class Engine:
         if not cfg or cfg.get("version") != 1:
             raise ValueError(f"optic.yaml: unsupported version {cfg.get('version') if cfg else None}")
         self.service_name = (cfg.get("service") or {}).get("name", "")
+        # The only thread from a customer's screenshot back to the record.
+        # Without it a support conversation starts at "roughly what time?",
+        # which under concurrency identifies the wrong request.
+        self.trace_response_header = (
+            ((cfg.get("service") or {}).get("trace") or {}).get("response_header", "")
+        )
         defaults = cfg.get("defaults") or {}
         cap = defaults.get("capture") or {}
         self._defaults = {

--- a/sdks/fastapi/pyproject.toml
+++ b/sdks/fastapi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "optictrace-fastapi"
-version = "0.2.0"
+version = "0.3.0"
 description = "OpticTrace middleware for FastAPI/ASGI — config-driven API telemetry & governance"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/fastapi/test_middleware.py
+++ b/sdks/fastapi/test_middleware.py
@@ -12,12 +12,15 @@ import tempfile
 from optictrace_fastapi import OpticTraceMiddleware
 from optictrace_fastapi.engine import Engine, redact_path, match_segments, split_path, REDACTED
 
+import re
 import yaml
 
 CONFIG = """
 version: 1
 service:
   name: fastapi-test
+  trace:
+    response_header: X-Trace-Id
 rules:
   - name: meter-ai
     match:
@@ -135,6 +138,15 @@ async def main():
     )
     resp_body = json.loads(sent[-1]["body"])
     assert resp_body["echo"]["card"]["number"] == "4111111111111111", "traffic must not be mutated"
+
+    # The only thread from a customer's screenshot back to the record. The Go
+    # proxy has always echoed it; the SDKs silently ignored the setting until a
+    # real app was pointed at one. In ASGI it has to ride on the
+    # http.response.start message — there is no later point to add a header.
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    echoed = dict(start["headers"]).get(b"x-trace-id", b"").decode()
+    assert re.fullmatch(r"[0-9a-f]{32}", echoed), f"trace id not echoed to the caller: {echoed!r}"
+    assert emitted[-1]["trace_id"] == echoed, "echoed header names a different trace than the record"
 
     await call(mw, "POST", "/auth/login",
                {"content-type": "application/json"}, json.dumps({"password": "hunter2"}).encode())

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -11,7 +11,7 @@ Tomcat.
 <dependency>
   <groupId>io.github.dwarka-prasad</groupId>
   <artifactId>optictrace-servlet</artifactId>
-  <version>0.9.0</version>
+  <version>0.10.0</version>
 </dependency>
 ```
 
@@ -58,7 +58,7 @@ than becoming its sibling.
 | Labels | `header:` `query:` `path:<n>` `static:` `json:` `json_response:`, each with an optional `\|<regex>` capture |
 | Meters | numeric paths for billing — read from the raw response even when the body is not stored |
 | Sampling | `sample`, plus tail-based `keep_errors` and `keep_slower_than` |
-| Trace | adopts an inbound `traceparent` or starts one |
+| Trace | adopts an inbound `traceparent` or starts one, and echoes the id on `service.trace.response_header` |
 | App logs | `OpticTraceLogHandler` |
 
 **Live traffic is never modified.** The response is teed as it is written, so

--- a/sdks/java/pom.xml
+++ b/sdks/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.dwarka-prasad</groupId>
   <artifactId>optictrace-servlet</artifactId>
-  <version>0.9.0</version>
+  <version>0.10.0</version>
   <packaging>jar</packaging>
 
   <name>OpticTrace Servlet SDK</name>

--- a/sdks/java/src/main/java/io/github/dwarkaprasad/optictrace/Engine.java
+++ b/sdks/java/src/main/java/io/github/dwarkaprasad/optictrace/Engine.java
@@ -26,6 +26,7 @@ public final class Engine {
     public static final String REDACTED = "[REDACTED]";
 
     private final String serviceName;
+    private final String traceResponseHeader;
     private final boolean defaultRequestBody;
     private final boolean defaultResponseBody;
     private final boolean defaultHeaders;
@@ -40,6 +41,7 @@ public final class Engine {
         }
         Map<String, Object> service = map(cfg.get("service"));
         this.serviceName = str(service.get("name"), "");
+        this.traceResponseHeader = str(map(service.get("trace")).get("response_header"), "");
 
         Map<String, Object> defaults = map(cfg.get("defaults"));
         Map<String, Object> capture = map(defaults.get("capture"));
@@ -57,6 +59,17 @@ public final class Engine {
 
     public String serviceName() {
         return serviceName;
+    }
+
+    /**
+     * Header to echo the trace id back to the caller on, or "" for none.
+     *
+     * <p>This is the only thread from a customer's screenshot back to the
+     * record. Without it a support conversation starts at "roughly what time?",
+     * which under concurrency identifies the wrong request.
+     */
+    public String traceResponseHeader() {
+        return traceResponseHeader;
     }
 
     /** Evaluate every rule against a request. Later rules win on capture flags; redactions, labels and meters accumulate. */

--- a/sdks/java/src/main/java/io/github/dwarkaprasad/optictrace/OpticTraceFilter.java
+++ b/sdks/java/src/main/java/io/github/dwarkaprasad/optictrace/OpticTraceFilter.java
@@ -44,6 +44,7 @@ public final class OpticTraceFilter implements Filter {
     private final String service;
     private final Shipper shipper;
     private final boolean consoleLog;
+    private final String traceResponseHeader;
 
     public OpticTraceFilter(String configPath, String agentUrl, String serviceName) throws IOException {
         this(loadConfig(configPath), agentUrl, serviceName, false);
@@ -53,6 +54,7 @@ public final class OpticTraceFilter implements Filter {
         this.engine = new Engine(config);
         this.service = serviceName != null && !serviceName.isEmpty() ? serviceName : engine.serviceName();
         this.consoleLog = consoleLog;
+        this.traceResponseHeader = engine.traceResponseHeader();
         this.shipper = agentUrl == null || agentUrl.isEmpty()
                 ? null
                 : new Shipper(agentUrl.replaceAll("/+$", "") + "/api/ingest", 4096, 1, Duration.ofSeconds(5));
@@ -89,6 +91,15 @@ public final class OpticTraceFilter implements Filter {
         // application runs so its logs and outbound calls can name this span.
         TraceContext ctx = TraceContext.fromHeader(request.getHeader(TraceContext.HEADER));
         TraceContext.set(ctx);
+
+        // Echo the trace id back to the caller, if configured. Set BEFORE the
+        // chain runs: once the application writes a byte the response is
+        // committed and a header set afterwards is silently discarded — which
+        // would look exactly like the feature working until someone tried to
+        // use it on a real response.
+        if (!traceResponseHeader.isEmpty()) {
+            response.setHeader(traceResponseHeader, ctx.traceId);
+        }
 
         CapturingRequest wrappedReq = new CapturingRequest(request, buffer && policy.captureRequestBody, policy.captureLimit);
         // Response bytes are buffered when the body is stored OR when a meter

--- a/sdks/java/src/test/java/io/github/dwarkaprasad/optictrace/SelfTest.java
+++ b/sdks/java/src/test/java/io/github/dwarkaprasad/optictrace/SelfTest.java
@@ -52,7 +52,9 @@ public final class SelfTest {
 
     private static final String CONFIG = """
             version: 1
-            service: { name: java-test }
+            service:
+              name: java-test
+              trace: { response_header: X-Trace-Id }
             defaults:
               capture: { request_body: true, response_body: true, headers: true }
             rules:
@@ -222,6 +224,13 @@ public final class SelfTest {
             check("region label captured by regex", "ap".equals(labels.get("region")));
             check("partner label read from the payload", "flipkart".equals(labels.get("partner")));
             check("outcome label read from the response", "captured".equals(labels.get("outcome")));
+            // The only thread from a customer's screenshot back to the record.
+            // The Go proxy has always echoed it; the SDKs silently ignored the
+            // setting until a real Spring Boot app was pointed at one.
+            check("trace id echoed to the caller on the configured header",
+                    String.valueOf(rec.get("trace_id")).equals(out.responseHeaders().get("x-trace-id")));
+            check("trace header set before the first byte, or a container drops it",
+                    out.traceHeaderSetBeforeBody());
         }
 
         // Restricted route: metadata only, but still attributable.
@@ -306,7 +315,8 @@ public final class SelfTest {
     }
 
     // --- a minimal servlet environment --------------------------------
-    private record Captured(Map<String, Object> record, byte[] clientBytes) {
+    private record Captured(Map<String, Object> record, byte[] clientBytes,
+                           Map<String, String> responseHeaders, boolean traceHeaderSetBeforeBody) {
     }
 
     /**
@@ -322,6 +332,9 @@ public final class SelfTest {
         Map<String, String> responseHeaders = new LinkedHashMap<>();
         responseHeaders.put("content-type", "application/json");
         int[] statusHolder = {status};
+        // A header set after the first byte is written is silently discarded by
+        // a real container, so the ORDER is the thing worth asserting.
+        boolean[] traceHeaderBeforeBody = {false};
 
         HttpServletRequest request = (HttpServletRequest) Proxy.newProxyInstance(
                 SelfTest.class.getClassLoader(), new Class<?>[]{HttpServletRequest.class},
@@ -329,7 +342,7 @@ public final class SelfTest {
 
         HttpServletResponse response = (HttpServletResponse) Proxy.newProxyInstance(
                 SelfTest.class.getClassLoader(), new Class<?>[]{HttpServletResponse.class},
-                responseHandler(clientSink, responseHeaders, statusHolder));
+                responseHandler(clientSink, responseHeaders, statusHolder, traceHeaderBeforeBody));
 
         List<Map<String, Object>> captured = new ArrayList<>();
         // The filter prints the record when no agent is configured; capture it
@@ -348,7 +361,8 @@ public final class SelfTest {
         for (String line : sink.toString().split("\n")) {
             if (line.startsWith("{")) captured.add(Policy.mapper().readValue(line, Map.class));
         }
-        return new Captured(captured.isEmpty() ? null : captured.get(captured.size() - 1), clientSink.toByteArray());
+        return new Captured(captured.isEmpty() ? null : captured.get(captured.size() - 1),
+                clientSink.toByteArray(), responseHeaders, traceHeaderBeforeBody[0]);
     }
 
     private static InvocationHandler requestHandler(String method, String path, String query,
@@ -388,8 +402,17 @@ public final class SelfTest {
     }
 
     private static InvocationHandler responseHandler(ByteArrayOutputStream sink,
-                                                     Map<String, String> headers, int[] status) {
+                                                     Map<String, String> headers, int[] status,
+                                                     boolean[] traceHeaderBeforeBody) {
         return (proxy, m, args) -> switch (m.getName()) {
+            case "setHeader", "addHeader" -> {
+                String name = String.valueOf(args[0]);
+                if (name.equalsIgnoreCase("X-Trace-Id") && sink.size() == 0) {
+                    traceHeaderBeforeBody[0] = true;
+                }
+                headers.put(name.toLowerCase(Locale.ROOT), String.valueOf(args[1]));
+                yield null;
+            }
             case "getStatus" -> status[0];
             case "setStatus" -> {
                 status[0] = (int) args[0];


### PR DESCRIPTION
Two bugs, both found by pointing a real Spring Boot app at a running agent
rather than exercising the SDKs through their own test doubles.

## `service.trace.response_header` was proxy-only

All three SDKs parsed the setting and never used it, so an SDK-instrumented
service returned no trace id to its caller. That header is the only thread
from a customer's screenshot back to the record; without it a support
conversation starts at *"roughly what time was that?"*, which under concurrent
traffic identifies the wrong request.

Each SDK now sets it **before the handler writes its first byte**, because a
header added after the response is committed is discarded — silently by a
servlet container, loudly by Node, and impossibly by ASGI, where headers ride
on the `http.response.start` message and there is no later point to add one.

## Header names from SDKs were stored as sent

Go's `http.Header` is canonical (`Authorization`); every SDK hands over what
the wire carried, which is lower case. `optictrace suggest` keys its coverage
check on the canonical name, so against SDK traffic it reported

```
✗ [high] header "authorization" on /api/v1/orders
    authentication headers are credentials (seen 57×)
```

on a route whose own rule already masked it. Advice to add a rule you already
have is worse than silence. Names are canonicalised at ingest; values are
untouched, having already been governed in-process. `/api/ingest` had no
server-side test at all before this.

## Verification

Every new check was re-run with its fix reverted and confirmed to fail, so
none of them is vacuous.

Against a live Spring Boot service (191 records, 342 log lines, 4 tenants):

- card number and bearer token absent from all telemetry, on both hops
- every checkout response carries `X-Trace-Id`, matching the record
- three legs per checkout share a trace id; inner legs name the outer as parent
- zero orphan log lines
- `keep_slower_than: 200ms` kept 15/15 slow bodies; `keep_errors` left 404s
  sampled, which is correct — it means 5xx
- `optictrace suggest` no longer reports the already-masked header

## Also

`examples/springboot-shop` — the Java SDK's first example, and the app that
found both bugs.

SDK versions: java `0.9.0` → `0.10.0`, express and fastapi `0.2.0` → `0.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
