### PR TITLE
optictrace scan was blind to span attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Versions `0.4.0`–`0.6.0` were development milestones that were never tagged;
 `0.7.0` is the first public release and contains all of that work.
 
+## [0.15.1] — 2026-08-20
+
+### Fixed
+
+- **`optictrace scan` did not look at span attributes.** Inner spans shipped in `0.15.0` added a surface the leak detector could not see: a Luhn-valid card number sitting in a stored `db.statement` produced `✓ no sensitive values found` and exit code 0. Since `scan -fail-on high` is the CI gate, a team would have got a green build over stored card data — on the one surface nobody had written a rule for yet, which is precisely what a value-based scan exists for.
+
+  Found by testing the released binary against the Spring Boot example rather than by reading the code: the statement was planted with no `telemetry.spans.redact` pattern configured, standing in for an operator who has not yet realised their driver interpolates parameters.
+
+  Both the CLI and `GET /api/scan` now scan span attributes and the error text, and report `spans_scanned` alongside records and log lines — "0 findings" over zero spans means something very different from 0 over three hundred. The suggested fix points at `telemetry.spans.redact`, not at `json_fields`, because a span attribute has no JSON path and suggesting one would be advice that silently does nothing.
+
 ## [0.15.0] — 2026-08-20
 
 ### Added
@@ -377,7 +387,8 @@ Measured with `make bench` (12th Gen Intel i5-1235U, Go 1.25):
 - Control-plane authentication is available but **off by default**.
 - Homebrew publishing is configured but disabled until a `homebrew-tap` repository exists.
 
-[Unreleased]: https://github.com/dwarka-prasad/optictrace/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/dwarka-prasad/optictrace/compare/v0.15.1...HEAD
+[0.15.1]: https://github.com/dwarka-prasad/optictrace/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/dwarka-prasad/optictrace/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/dwarka-prasad/optictrace/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/dwarka-prasad/optictrace/compare/v0.12.0...v0.13.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Prometheus dimensions.
 
 [![Go](https://img.shields.io/badge/Go-1.25-00ADD8?logo=go&logoColor=white)](https://go.dev)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/status-v0.15.0-brightgreen)](#roadmap)
+[![Status](https://img.shields.io/badge/status-v0.15.1-brightgreen)](#roadmap)
 
 **[optictrace product page →](https://dwarka-prasad.github.io/optictrace/)**
 
@@ -547,7 +547,7 @@ for a complete workflow. This repo dogfoods it in
 | `GET /api/routes` | Per-route latency breakdown |
 | `GET /api/rules/stats` | Rules joined with live match counts |
 | `GET /api/usage` | Per-consumer usage and cost (`&format=csv`) |
-| `GET /api/scan` | Sensitive values found outside your rules (masked) |
+| `GET /api/scan` | Sensitive values found outside your rules, across payloads, log lines **and span attributes** (masked) |
 | `GET /api/services` | Per-service aggregates (fleet view) |
 | `GET /api/traces` | Recent traces, one row each (`?errors=1` / `?service=` / `?q=` / `?label.<k>=`) |
 | `GET /api/spec` | OpenAPI inferred from traffic |

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -406,6 +406,7 @@ func scanTraffic(configPath string, window time.Duration, failOn string) {
 	// is structured and can be masked by JSON path, a log line is free text
 	// written by whoever was debugging that day.
 	scanAppLogs(sc, cfg, window)
+	scanSpans(sc, cfg, window)
 	report := sc.Report()
 	crit, high, med := report.Counts()
 
@@ -478,10 +479,21 @@ func ago(t time.Time) string {
 // means something very different from 0 findings over 40,000 of them, and the
 // difference is invisible unless it is printed.
 func scannedSummary(r *scan.Report) string {
-	if r.LinesScanned == 0 {
-		return fmt.Sprintf("%d record(s)", r.Scanned)
+	parts := []string{fmt.Sprintf("%d record(s)", r.Scanned)}
+	if r.LinesScanned > 0 {
+		parts = append(parts, fmt.Sprintf("%d log line(s)", r.LinesScanned))
 	}
-	return fmt.Sprintf("%d record(s) and %d log line(s)", r.Scanned, r.LinesScanned)
+	if r.SpansScanned > 0 {
+		parts = append(parts, fmt.Sprintf("%d span(s)", r.SpansScanned))
+	}
+	switch len(parts) {
+	case 1:
+		return parts[0]
+	case 2:
+		return parts[0] + " and " + parts[1]
+	default:
+		return strings.Join(parts[:len(parts)-1], ", ") + " and " + parts[len(parts)-1]
+	}
 }
 
 // scanAppLogs feeds stored application log lines to the scanner. A store
@@ -547,6 +559,44 @@ func scanAppLogs(sc *scan.Scanner, cfg *config.Config, window time.Duration) {
 			sc.AddAppLog(&lines[i])
 		}
 		offset += len(lines)
+		if int64(offset) >= total {
+			return
+		}
+	}
+}
+
+// scanSpans feeds stored inner spans to the scanner.
+//
+// The same shape as scanAppLogs, and needed for the same reason: a statement is
+// free text a driver assembled, and the parameter it interpolated is the
+// customer's. Without this the leak detector reported clean on the one surface
+// nobody had written a rule for yet.
+func scanSpans(sc *scan.Scanner, cfg *config.Config, window time.Duration) {
+	if cfg == nil || cfg.Telemetry.Spans == nil || !cfg.Telemetry.Spans.Enabled {
+		return
+	}
+	st, err := openStore(&cfg.Telemetry.Store)
+	if err != nil {
+		return
+	}
+	defer st.Close()
+	ss, ok := st.(store.SpanStore)
+	if !ok {
+		return
+	}
+	since := time.Now().Add(-window)
+	limit := store.AnalysisLimit(cfg.Telemetry.Store.AnalysisMaxRows)
+	for offset := 0; offset < limit; {
+		spans, total, err := ss.QuerySpans(context.Background(), store.SpanFilter{
+			Since: since, Limit: 500, Offset: offset,
+		})
+		if err != nil || len(spans) == 0 {
+			return
+		}
+		for i := range spans {
+			sc.AddSpan(&spans[i])
+		}
+		offset += len(spans)
 		if int64(offset) >= total {
 			return
 		}

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -605,6 +605,29 @@ func (s *Server) scan(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// And the inner spans. A statement is free text a driver assembled, and
+	// the parameter it interpolated is the customer's — so it is exactly the
+	// surface a value-based scan exists for.
+	if s.SpanStore != nil {
+		offset := 0
+		for {
+			spans, total, err := s.SpanStore.QuerySpans(r.Context(), store.SpanFilter{
+				Since: since, Limit: 500, Offset: offset,
+			})
+			if err != nil {
+				httpError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			for i := range spans {
+				sc.AddSpan(&spans[i])
+			}
+			offset += len(spans)
+			if len(spans) == 0 || int64(offset) >= total || offset >= s.analysisRows() {
+				break
+			}
+		}
+	}
+
 	report := sc.Report()
 	ext.NoteAccess(r.Context(), ext.Accessed{Count: report.Scanned, Filter: auditableQuery(r)})
 	crit, high, med := report.Counts()
@@ -616,6 +639,7 @@ func (s *Server) scan(w http.ResponseWriter, r *http.Request) {
 		// Reported so "0 findings" can be read honestly: none over zero log
 		// lines means something very different from none over forty thousand.
 		"log_lines_scanned": report.LinesScanned,
+		"spans_scanned":     report.SpansScanned,
 		"since":             report.Since,
 		"critical":          crit,
 		"high":              high,

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -38,7 +38,11 @@ type Report struct {
 	// LinesScanned counts application log lines examined. Reported separately
 	// from records because "0 findings" means something very different when
 	// no log lines were looked at than when thousands were.
-	LinesScanned int       `json:"log_lines_scanned"`
+	LinesScanned int `json:"log_lines_scanned"`
+	// SpansScanned counts inner spans examined, reported separately for the
+	// same reason: "0 findings" means something very different when no span
+	// attributes were looked at than when thousands were.
+	SpansScanned int       `json:"spans_scanned"`
 	Since        time.Time `json:"since"`
 	Findings     []Finding `json:"findings"`
 }
@@ -83,6 +87,7 @@ type key struct{ kind, method, route, location, field string }
 // reachable without authentication. Folding incrementally costs one record.
 type Scanner struct {
 	linesScanned int
+	spansScanned int
 	agg          map[key]*Finding
 	scanned      int
 	since        time.Time
@@ -199,6 +204,63 @@ func (s *Scanner) AddAppLog(l *ext.AppLog) {
 	}
 }
 
+// AddSpan scans one inner span's attributes and error text.
+//
+// This surface is easy to forget and easy to leak through. A payload has a JSON
+// path a rule can name; a statement is free text that a driver assembled, and
+// the parameter it interpolated is the customer's. A card number sitting in
+// `db.statement` was invisible to this scanner until it looked here, which
+// meant the leak detector reported clean on the one surface nobody had written
+// a rule for yet.
+func (s *Scanner) AddSpan(sp *ext.Span) {
+	s.spansScanned++
+
+	record := func(field, value string) {
+		for _, m := range FindWith(s.detectors, value) {
+			// Keyed by operation NAME rather than route: the span's route is a
+			// producer-supplied hint, and a figure someone reads as fact
+			// should not rest on it. The name is what identifies the operation
+			// to fix anyway.
+			k := key{m.Kind, sp.Service, "span:" + sp.Name, "span_attr", field}
+			f := s.agg[k]
+			if f == nil {
+				f = &Finding{
+					Kind: m.Kind, Severity: m.Severity, Why: m.Why,
+					Method: sp.Service, Route: "span:" + sp.Name,
+					Location: "span_attr", Field: field,
+					Sample: m.Masked, FirstAt: sp.Start,
+					Suggest: suggestSpanAttr(field),
+				}
+				s.agg[k] = f
+			}
+			f.Count++
+			if sp.Start.Before(f.FirstAt) {
+				f.FirstAt = sp.Start
+			}
+			if sp.Start.After(f.LastAt) {
+				f.LastAt = sp.Start
+			}
+		}
+	}
+
+	for name, val := range sp.Attrs {
+		record(name, val)
+	}
+	// A driver error quotes the statement that failed, parameters included.
+	record("error", sp.Error)
+}
+
+// suggestSpanAttr produces the fix for a value found in a span attribute.
+//
+// Deliberately not a json_fields suggestion: there is no JSON path here, so
+// the fix is a pattern, or the attribute key, under telemetry.spans.redact.
+func suggestSpanAttr(field string) string {
+	if field == "error" {
+		return "telemetry:\n  spans:\n    redact:\n      patterns: ['<a regex matching this value>']"
+	}
+	return fmt.Sprintf("telemetry:\n  spans:\n    redact:\n      fields: [%s]", field)
+}
+
 // suggestAppLog produces the fix for a value found in a log line.
 //
 // Deliberately different from the payload suggestion: there is no JSON path to
@@ -228,7 +290,8 @@ func (s *Scanner) Report() *Report {
 		}
 		return out[i].Field < out[j].Field
 	})
-	return &Report{Scanned: s.scanned, LinesScanned: s.linesScanned, Since: s.since, Findings: out}
+	return &Report{Scanned: s.scanned, LinesScanned: s.linesScanned,
+		SpansScanned: s.spansScanned, Since: s.since, Findings: out}
 }
 
 // Records scans a slice of stored telemetry. Equivalent to feeding each record

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dwarka-prasad/optictrace/ext"
 	"github.com/dwarka-prasad/optictrace/internal/store"
 )
 
@@ -148,5 +149,74 @@ func TestCleanTrafficProducesNoFindings(t *testing.T) {
 	}
 	if rep.HasAtLeast(SevMedium) {
 		t.Error("gate should not trip on clean traffic")
+	}
+}
+
+// A statement is free text a driver assembled, and the parameter it
+// interpolated is the customer's. The leak detector reported CLEAN on exactly
+// that surface until it looked there — and since `scan -fail-on high` is the CI
+// gate, a team got a green build over a stored card number.
+func TestScannerFindsSecretsInSpanAttributes(t *testing.T) {
+	sc := NewScanner(time.Now().Add(-time.Hour))
+	sc.AddSpan(&ext.Span{
+		Start: time.Now(), Service: "shop", Name: "db.query", Kind: "db",
+		Attrs: map[string]string{
+			"db.statement": "SELECT * FROM cards WHERE number = '4111111111111111'",
+			"db.rows":      "1",
+		},
+	})
+	sc.AddSpan(&ext.Span{
+		Start: time.Now(), Service: "shop", Name: "db.insert", Kind: "db",
+		// A driver error quotes the statement that failed, parameters included.
+		Error: "duplicate key for a@b.com",
+	})
+
+	rep := sc.Report()
+	if rep.SpansScanned != 2 {
+		t.Errorf("spans scanned = %d, want 2 — the count is what distinguishes "+
+			"'nothing found' from 'nothing looked at'", rep.SpansScanned)
+	}
+	if len(rep.Findings) == 0 {
+		t.Fatal("no findings: a Luhn-valid card number in db.statement must be caught")
+	}
+
+	var card, email *Finding
+	for i := range rep.Findings {
+		f := &rep.Findings[i]
+		if f.Location != "span_attr" {
+			t.Errorf("finding located in %q, want span_attr", f.Location)
+		}
+		switch f.Field {
+		case "db.statement":
+			card = f
+		case "error":
+			email = f
+		}
+	}
+	if card == nil {
+		t.Fatal("the card number in db.statement was not found")
+	}
+	if card.Severity != SevHigh && card.Severity != SevCritical {
+		t.Errorf("card severity = %q, want high or above", card.Severity)
+	}
+	if !strings.Contains(card.Sample, "••") {
+		t.Errorf("the sample must be masked, got %q", card.Sample)
+	}
+	if strings.Contains(card.Sample, "4111111111111111") {
+		t.Errorf("a finding must never quote the value it found: %q", card.Sample)
+	}
+	// The fix has to be one that can actually work. Suggesting json_fields for
+	// a span attribute is advice that silently does nothing.
+	if !strings.Contains(card.Suggest, "spans:") || !strings.Contains(card.Suggest, "redact") {
+		t.Errorf("suggestion does not point at telemetry.spans.redact: %q", card.Suggest)
+	}
+	if strings.Contains(card.Suggest, "json_fields") {
+		t.Errorf("a span attribute has no JSON path; suggestion was %q", card.Suggest)
+	}
+	if card.Route != "span:db.query" {
+		t.Errorf("route = %q, want the operation name so the fix is locatable", card.Route)
+	}
+	if email == nil {
+		t.Error("an email quoted in a driver error was not found")
 	}
 }


### PR DESCRIPTION
Inner spans shipped an hour ago added a surface the leak detector could not see.
A Luhn-valid card number sitting in a stored \`db.statement\` produced:

\`\`\`
✓ scanned 1 record(s) over 1h0m0s — no sensitive values found outside your rules
exit 0
\`\`\`

\`scan -fail-on high\` is the **CI gate**, so a team would have got a green build
over stored card data — on the one surface nobody had written a rule for yet,
which is exactly what a value-based scan exists for. A payload has a JSON path a
rule can name; a statement is free text a driver assembled, and the parameter it
interpolated is the customer's.

**Found by testing the released binary against the Spring Boot example**, not by
reading the code. The statement was planted with no \`telemetry.spans.redact\`
pattern configured, standing in for an operator who has not yet realised their
driver interpolates its parameters.

Both the CLI and \`GET /api/scan\` now scan span attributes and the error text — a
driver error quotes the statement that failed, parameters included. The same
store now reports:

\`\`\`
⚠ [high] credit-card in shop span:db.query → span_attr.db.statement
    a Luhn-valid card number — PCI-DSS scope · sample 41••••••••••••11
    fix: telemetry:
           spans:
             redact:
               fields: [db.statement]
exit 1
\`\`\`

\`spans_scanned\` is reported alongside records and log lines, for the reason the
line count already exists: "0 findings" over zero spans means something very
different from 0 over three hundred.

The suggested fix names \`telemetry.spans.redact\` rather than \`json_fields\`. A
span attribute has no JSON path, and suggesting one would be advice that
silently does nothing — the test asserts that, along with the finding never
quoting the value it found.

Verified non-vacuously: the regression test fails with the attribute loop
disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)