### PR TITLE
Java SDK: async handlers were recorded as near-instant, with no body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Versions `0.4.0`–`0.6.0` were development milestones that were never tagged;
 `0.7.0` is the first public release and contains all of that work.
 
+## [0.15.2] — 2026-08-20
+
+### Fixed
+
+- **The Java SDK recorded async handlers as near-instant, with no response body.** A Spring MVC async handler — `Callable`, `DeferredResult`, `CompletableFuture`, `WebAsyncTask` — returns from the filter chain when the request is *parked*, not when it is finished. `OpticTraceFilter` emitted its record there, which measured **3ms for a 125ms request** and lost the response body entirely, because the body had not been written yet.
+
+  That is the worst way for a latency figure to be wrong: the endpoint looked fast rather than broken, and every percentile built on it was quietly understated.
+
+  The filter now checks `isAsyncStarted()` and, when it is, defers to the container's `AsyncListener.onComplete` — the only thing that knows when an async exchange is really over. `onTimeout` and `onError` emit too, since a timed-out async request is the interesting kind, and `onStartAsync` re-registers because listeners do not survive a re-dispatch. Emission is once-only: a record counted twice is worse than one counted late, because it doubles every count and drags the percentiles toward the duplicate.
+
+  The thread-local span is still cleared on the request thread regardless — it is pooled, and leaving a span on it would attribute the next request that thread serves to the wrong trace.
+
+  Found by pointing the question "how is this different from a Spring filter?" at a running app instead of at the source. `examples/springboot-shop` keeps `/api/v1/sync` and `/api/v1/async` as a live check: they do identical work on different threads, so their recorded durations should agree.
+
+  Java SDK `0.10.0` → `0.10.1`.
+
 ## [0.15.1] — 2026-08-20
 
 ### Fixed
@@ -387,7 +403,8 @@ Measured with `make bench` (12th Gen Intel i5-1235U, Go 1.25):
 - Control-plane authentication is available but **off by default**.
 - Homebrew publishing is configured but disabled until a `homebrew-tap` repository exists.
 
-[Unreleased]: https://github.com/dwarka-prasad/optictrace/compare/v0.15.1...HEAD
+[Unreleased]: https://github.com/dwarka-prasad/optictrace/compare/v0.15.2...HEAD
+[0.15.2]: https://github.com/dwarka-prasad/optictrace/compare/v0.15.1...v0.15.2
 [0.15.1]: https://github.com/dwarka-prasad/optictrace/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/dwarka-prasad/optictrace/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/dwarka-prasad/optictrace/compare/v0.13.0...v0.14.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Prometheus dimensions.
 
 [![Go](https://img.shields.io/badge/Go-1.25-00ADD8?logo=go&logoColor=white)](https://go.dev)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/status-v0.15.1-brightgreen)](#roadmap)
+[![Status](https://img.shields.io/badge/status-v0.15.2-brightgreen)](#roadmap)
 
 **[optictrace product page →](https://dwarka-prasad.github.io/optictrace/)**
 

--- a/docs/integrate.html
+++ b/docs/integrate.html
@@ -487,7 +487,7 @@ httpx.post(url, headers=outbound_headers(), json=payload)</pre>
 <pre>&lt;dependency&gt;
   &lt;groupId&gt;io.github.dwarka-prasad&lt;/groupId&gt;
   &lt;artifactId&gt;optictrace-servlet&lt;/artifactId&gt;
-  &lt;version&gt;0.10.0&lt;/version&gt;
+  &lt;version&gt;0.10.1&lt;/version&gt;
 &lt;/dependency&gt;</pre>
 <pre><span class="k">@Bean</span>
 FilterRegistrationBean&lt;OpticTraceFilter&gt; optictrace() <span class="k">throws</span> IOException {

--- a/examples/springboot-shop/README.md
+++ b/examples/springboot-shop/README.md
@@ -52,6 +52,7 @@ Dashboard: <http://127.0.0.1:9095>
 | **Trace id to the caller** | Responses carry `X-Trace-Id`, so a support conversation can start from a screenshot instead of a timestamp. |
 | **Inner spans** | `ProductRepository` names every operation: an H2 query, a cache lookup, an index refresh nested inside an insert, and the acquirer call in `PaymentsController`. The waterfall shows all of them under the hop that ran them. |
 | **Governed attributes** | `saveOrder` deliberately records an *interpolated* statement, the way a driver logging its own SQL would. The customer's email is stored `[REDACTED]` — which is why span attributes are governed at all. |
+| **Async handlers** | `/api/v1/sync` and `/api/v1/async` do identical work on different threads. Their recorded durations agree — the filter defers to the container's `onComplete` rather than recording when an async request is merely parked. |
 | **An N+1, on purpose** | `stockFor` runs one query per sku. On the breakdown it shows as one named operation with a ×4 per-request multiplier — the shape no latency chart can show you. |
 
 ## Wiring

--- a/examples/springboot-shop/pom.xml
+++ b/examples/springboot-shop/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>io.github.dwarka-prasad</groupId>
       <artifactId>optictrace-servlet</artifactId>
-      <version>0.10.0</version>
+      <version>0.10.1</version>
     </dependency>
   </dependencies>
 

--- a/examples/springboot-shop/src/main/java/com/example/shop/AsyncProbe.java
+++ b/examples/springboot-shop/src/main/java/com/example/shop/AsyncProbe.java
@@ -1,0 +1,38 @@
+package com.example.shop;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+/**
+ * The async case, kept as a live regression check.
+ *
+ * <p>A Spring MVC async handler returns from the filter chain when the request
+ * is PARKED, not when it is finished — which is the one place a plain servlet
+ * {@code Filter} has a sharp edge. Recording at that moment measured 3ms for a
+ * 125ms request and lost the response body, so the filter now defers to the
+ * container's {@code onComplete}.
+ *
+ * <p>The two endpoints do identical work on different threads, so their
+ * recorded durations should agree. If {@code /async} ever reads as
+ * near-instant again, that regression is back.
+ */
+@RestController
+public class AsyncProbe {
+
+    @GetMapping("/api/v1/async")
+    public Callable<Map<String, Object>> async() {
+        return () -> {
+            Thread.sleep(120);          // work on the async thread
+            return Map.of("ok", true, "where", "async thread", "slept_ms", 120);
+        };
+    }
+
+    @GetMapping("/api/v1/sync")
+    public Map<String, Object> sync() throws InterruptedException {
+        Thread.sleep(120);              // the same work, on the request thread
+        return Map.of("ok", true, "where", "request thread", "slept_ms", 120);
+    }
+}

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -11,7 +11,7 @@ Tomcat.
 <dependency>
   <groupId>io.github.dwarka-prasad</groupId>
   <artifactId>optictrace-servlet</artifactId>
-  <version>0.10.0</version>
+  <version>0.10.1</version>
 </dependency>
 ```
 

--- a/sdks/java/pom.xml
+++ b/sdks/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.dwarka-prasad</groupId>
   <artifactId>optictrace-servlet</artifactId>
-  <version>0.10.0</version>
+  <version>0.10.1</version>
   <packaging>jar</packaging>
 
   <name>OpticTrace Servlet SDK</name>

--- a/sdks/java/src/main/java/io/github/dwarkaprasad/optictrace/OpticTraceFilter.java
+++ b/sdks/java/src/main/java/io/github/dwarkaprasad/optictrace/OpticTraceFilter.java
@@ -1,6 +1,8 @@
 package io.github.dwarkaprasad.optictrace;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -21,6 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * OpticTrace servlet filter — governance, correlation and telemetry for any
@@ -109,14 +112,20 @@ public final class OpticTraceFilter implements Filter {
                 (buffer && policy.captureResponseBody) || policy.hasMeters(), policy.captureLimit);
 
         long start = System.nanoTime();
-        int status = 200;
-        try {
-            chain.doFilter(wrappedReq, wrappedRes);
-            status = wrappedRes.getStatus();
-        } finally {
-            wrappedRes.flushCapture();
+        // Emitted exactly once, from whichever path finishes the exchange. A
+        // request that is recorded twice is worse than one recorded late: it
+        // doubles every count and drags the percentiles toward the duplicate.
+        AtomicBoolean emitted = new AtomicBoolean();
+        Runnable emit = () -> {
+            if (!emitted.compareAndSet(false, true)) return;
+            try {
+                wrappedRes.flushCapture();
+            } catch (IOException ignored) {
+                // The response is already gone; losing the captured copy is
+                // not a reason to fail the exchange that succeeded.
+            }
             double durationMs = (System.nanoTime() - start) / 1_000_000.0;
-            TraceContext.clear();
+            int status = wrappedRes.getStatus();
 
             // The record is ALWAYS emitted: metrics and metadata are never
             // sampled, and a request that produced no record at all is
@@ -130,6 +139,54 @@ public final class OpticTraceFilter implements Filter {
                 System.out.println(writeJson(record));
             }
             if (shipper != null) shipper.enqueue(record);
+        };
+
+        try {
+            chain.doFilter(wrappedReq, wrappedRes);
+        } finally {
+            // The thread-local is cleared on THIS thread regardless: it is
+            // pooled, and leaving a span on it attributes the next request
+            // served by this thread to the wrong trace.
+            TraceContext.clear();
+
+            if (request.isAsyncStarted()) {
+                // A Spring MVC async handler — Callable, DeferredResult,
+                // CompletableFuture — returns from the chain when the request
+                // is PARKED, not when it is finished. Emitting here recorded
+                // 5ms for a 125ms request and lost the response body entirely,
+                // because the body had not been written yet.
+                //
+                // So hand off to the container: onComplete fires once the
+                // response really is done, on whichever thread finished it.
+                request.getAsyncContext().addListener(new AsyncListener() {
+                    @Override
+                    public void onComplete(AsyncEvent event) {
+                        emit.run();
+                    }
+
+                    @Override
+                    public void onTimeout(AsyncEvent event) {
+                        // A timed-out async request still happened, and it is
+                        // the interesting kind. onComplete follows, and the
+                        // once-only guard makes the pair safe.
+                        emit.run();
+                    }
+
+                    @Override
+                    public void onError(AsyncEvent event) {
+                        emit.run();
+                    }
+
+                    @Override
+                    public void onStartAsync(AsyncEvent event) throws IOException {
+                        // Listeners do not carry across a re-dispatch, so
+                        // re-register or the second cycle records nothing.
+                        event.getAsyncContext().addListener(this);
+                    }
+                });
+            } else {
+                emit.run();
+            }
         }
     }
 

--- a/sdks/java/src/test/java/io/github/dwarkaprasad/optictrace/SelfTest.java
+++ b/sdks/java/src/test/java/io/github/dwarkaprasad/optictrace/SelfTest.java
@@ -1,6 +1,9 @@
 package io.github.dwarkaprasad.optictrace;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
 import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.ServletOutputStream;
@@ -38,6 +41,7 @@ public final class SelfTest {
         engineChecks();
         traceChecks();
         filterChecks();
+        asyncChecks();
         logChecks();
 
         System.out.println();
@@ -184,6 +188,139 @@ public final class SelfTest {
                 TraceContext.outboundHeaders().get("traceparent").contains(adopted.spanId));
         TraceContext.clear();
         check("no span outside a request", TraceContext.outboundHeaders().isEmpty());
+    }
+
+    // ------------------------------------------------------------------
+    /**
+     * A Spring MVC async handler — Callable, DeferredResult, CompletableFuture
+     * — returns from the filter chain when the request is PARKED, not when it
+     * is finished. Emitting the record there measured 5ms for a 125ms request
+     * and lost the response body entirely, because the body had not been
+     * written yet. It looked like a fast endpoint rather than a broken one,
+     * which is the worst way for a latency figure to be wrong.
+     *
+     * The container is the only thing that knows when an async exchange is
+     * really over, so the record now comes from its onComplete callback.
+     */
+    @SuppressWarnings("unchecked")
+    private static void asyncChecks() throws Exception {
+        Map<String, Object> cfg = (Map<String, Object>) new Yaml().load(CONFIG);
+        OpticTraceFilter filter = new OpticTraceFilter(cfg, null, "java-test", false);
+
+        byte[] responseBody = "{\"where\":\"async thread\"}".getBytes();
+        Async out = invokeAsync(filter, "POST", "/payments/charge",
+                Map.of("content-type", "application/json", "x-tenant-id", "acme"),
+                "{\"amount\":1}".getBytes(), responseBody, 200, 40);
+
+        check("nothing is recorded while the request is still parked", out.beforeComplete == 0);
+        check("exactly one record once the container says the exchange is done",
+                out.records.size() == 1);
+        if (out.records.size() == 1) {
+            Map<String, Object> rec = out.records.get(0);
+            double dur = ((Number) rec.get("duration_ms")).doubleValue();
+            check("the duration covers the async work, not just the parking (" + dur + "ms)",
+                    dur >= 35);
+            check("the response body written on the async thread is captured",
+                    String.valueOf(rec.get("response_body")).contains("async thread"));
+            check("status read after completion", Integer.valueOf(200).equals(rec.get("status")));
+        }
+        check("a second onComplete cannot double count", out.afterSecondComplete == 1);
+    }
+
+    private record Async(java.util.List<Map<String, Object>> records, int beforeComplete,
+                         int afterSecondComplete) {
+    }
+
+    /**
+     * Drives the filter through an async lifecycle: the chain starts async and
+     * returns, the response is written afterwards, then the container fires
+     * onComplete — the same order Tomcat uses.
+     */
+    @SuppressWarnings("unchecked")
+    private static Async invokeAsync(OpticTraceFilter filter, String method, String path,
+                                     Map<String, String> headers, byte[] requestBody,
+                                     byte[] responseBody, int status, long workMillis) throws Exception {
+        ByteArrayOutputStream clientSink = new ByteArrayOutputStream();
+        Map<String, String> responseHeaders = new LinkedHashMap<>();
+        responseHeaders.put("content-type", "application/json");
+        int[] statusHolder = {status};
+        boolean[] traceHeaderBeforeBody = {false};
+        boolean[] asyncStarted = {false};
+        java.util.List<AsyncListener> listeners = new ArrayList<>();
+
+        HttpServletResponse response = (HttpServletResponse) Proxy.newProxyInstance(
+                SelfTest.class.getClassLoader(), new Class<?>[]{HttpServletResponse.class},
+                responseHandler(clientSink, responseHeaders, statusHolder, traceHeaderBeforeBody));
+
+        InvocationHandler base = requestHandler(method, path, null, headers, requestBody);
+        HttpServletRequest[] requestHolder = new HttpServletRequest[1];
+        // One AsyncContext for the whole lifecycle: AsyncEvent's constructor
+        // dereferences it, so it cannot be null, and re-registration in
+        // onStartAsync has to land back on the same list.
+        AsyncContext asyncCtx = (AsyncContext) Proxy.newProxyInstance(
+                SelfTest.class.getClassLoader(), new Class<?>[]{AsyncContext.class},
+                (p2, m2, a2) -> switch (m2.getName()) {
+                    case "addListener" -> {
+                        listeners.add((AsyncListener) a2[0]);
+                        yield null;
+                    }
+                    case "getRequest" -> requestHolder[0];
+                    default -> defaultValue(m2);
+                });
+        HttpServletRequest request = (HttpServletRequest) Proxy.newProxyInstance(
+                SelfTest.class.getClassLoader(), new Class<?>[]{HttpServletRequest.class},
+                (proxy, m, args) -> switch (m.getName()) {
+                    case "isAsyncStarted" -> asyncStarted[0];
+                    case "getAsyncContext" -> asyncCtx;
+                    default -> base.invoke(proxy, m, args);
+                });
+        requestHolder[0] = request;
+
+        java.io.PrintStream original = System.out;
+        ByteArrayOutputStream sink = new ByteArrayOutputStream();
+        System.setOut(new java.io.PrintStream(sink));
+        ServletOutputStream[] captured = new ServletOutputStream[1];
+        try {
+            filter.doFilter(request, response, (req, res) -> {
+                req.getInputStream().readAllBytes();
+                // The handler parks the request and returns without writing.
+                asyncStarted[0] = true;
+                captured[0] = res.getOutputStream();
+            });
+
+            int before = countRecords(sink);
+
+            // The async thread does the work and writes the response.
+            Thread.sleep(workMillis);
+            captured[0].write(responseBody);
+
+            // Only now does the container consider the exchange complete.
+            for (AsyncListener l : new ArrayList<>(listeners)) {
+                l.onComplete(new AsyncEvent(asyncCtx));
+            }
+            int after = countRecords(sink);
+            // A container that fires onComplete twice must not double count.
+            for (AsyncListener l : new ArrayList<>(listeners)) {
+                l.onComplete(new AsyncEvent(asyncCtx));
+            }
+            int afterSecond = countRecords(sink);
+
+            java.util.List<Map<String, Object>> records = new ArrayList<>();
+            for (String line : sink.toString().split("\n")) {
+                if (line.startsWith("{")) records.add(Policy.mapper().readValue(line, Map.class));
+            }
+            return new Async(records, before, afterSecond == after ? afterSecond : -1);
+        } finally {
+            System.setOut(original);
+        }
+    }
+
+    private static int countRecords(ByteArrayOutputStream sink) {
+        int n = 0;
+        for (String line : sink.toString().split("\n")) {
+            if (line.startsWith("{")) n++;
+        }
+        return n;
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
A Spring MVC async handler — `Callable`, `DeferredResult`, `CompletableFuture`,
`WebAsyncTask` — returns from the filter chain when the request is **parked**,
not when it is finished. `OpticTraceFilter` emitted its record there.

Measured against `examples/springboot-shop`, two endpoints doing identical work
on different threads:

```
/api/v1/sync     161.0ms   body captured
/api/v1/async      3.0ms   body MISSING
```

That is the worst way for a latency figure to be wrong. The endpoint reads as
**fast rather than broken**, and every percentile built on it is quietly
understated — on a tool whose whole claim is that its numbers can be trusted.

## The fix

The filter checks `isAsyncStarted()` and defers to the container's
`AsyncListener.onComplete`, which is the only thing that knows when an async
exchange is really over.

- `onTimeout` and `onError` emit too — a timed-out async request is the
  interesting kind.
- `onStartAsync` re-registers, because listeners do not survive a re-dispatch
  and the second cycle would otherwise record nothing.
- Emission is once-only behind an `AtomicBoolean`. A record counted twice is
  worse than one counted late: it doubles every count and drags the percentiles
  toward the duplicate. A container firing `onComplete` twice is covered.
- The thread-local span is still cleared on the request thread regardless of
  which path emits — that thread is pooled, and leaving a span on it would
  attribute the next request it serves to the wrong trace.

After:

```
/api/v1/async    124.2ms   body captured
/api/v1/sync     121.8ms   body captured
```

## How it was found

By pointing the question *"how is this different from a Spring filter?"* at a
running app rather than at the source. The answer is that it **is** one — and
this is the sharp edge that answer hides.

## Tests

Six checks added to `SelfTest` (61 → 67), driving a real async lifecycle through
dynamic proxies: parked, written on another thread, then `onComplete`. All three
behavioural checks fail with the async branch disabled:

```
✗ nothing is recorded while the request is still parked
✗ the duration covers the async work, not just the parking (0.03614ms)
✗ the response body written on the async thread is captured
```

The example keeps `/api/v1/sync` and `/api/v1/async` as a live regression check
that their recorded durations agree.

Java SDK `0.10.0` → `0.10.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)